### PR TITLE
Clear output dir on every run to avoid orphaned files

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
+import com.google.common.io.MoreFiles;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.SneakyThrows;
 import net.jodah.typetools.TypeResolver;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
@@ -61,6 +63,8 @@ public class ConfigGenerator {
           + "Scanned: " + basePackage);
     }
 
+    initOutputDirectory(outputFolder);
+
     for (Class<? extends CCDConfig> configType : configTypes) {
       Objenesis objenesis = new ObjenesisStd();
       CCDConfig config = objenesis.newInstance(configType);
@@ -82,7 +86,7 @@ public class ConfigGenerator {
         builder.environment);
   }
 
-  public void writeConfig(File outputfolder, ResolvedCCDConfig config) {
+  private void writeConfig(File outputfolder, ResolvedCCDConfig config) {
     outputfolder.mkdirs();
     CaseEventGenerator.writeEvents(outputfolder, config.builder.caseType, config.events);
     CaseEventToFieldsGenerator.writeEvents(outputfolder, config.events, config.builder.caseType);
@@ -111,6 +115,14 @@ public class ConfigGenerator {
         eventPermissions);
     WorkBasketGenerator.generate(outputfolder, config.builder.caseType, config.builder);
     SearchFieldAndResultGenerator.generate(outputfolder, config.builder.caseType, config.builder);
+  }
+
+  @SneakyThrows
+  private void initOutputDirectory(File outputfolder) {
+    if (outputfolder.exists() && outputfolder.isDirectory()) {
+      MoreFiles.deleteRecursively(outputfolder.toPath());
+    }
+    outputfolder.mkdirs();
   }
 
   private void generateCaseType(File outputfolder, ConfigBuilderImpl builder) {

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/FPLConfigGenerationTests.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/FPLConfigGenerationTests.java
@@ -311,10 +311,12 @@ public class FPLConfigGenerationTests {
             }
 
         } catch (Exception e) {
-            System.out.println("Generated files:");
-            for (Iterator<File> it = FileUtils.iterateFiles(prodConfig.toFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE); it.hasNext(); ) {
-                File f = it.next();
-                System.out.println(f.getPath());
+            if (prodConfig.toFile().exists()) {
+                System.out.println("Generated files:");
+                for (Iterator<File> it = FileUtils.iterateFiles(prodConfig.toFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE); it.hasNext(); ) {
+                    File f = it.next();
+                    System.out.println(f.getPath());
+                }
             }
             throw e;
         }


### PR DESCRIPTION
### Change description ###

Clear output dir on every run to avoid orphaned files

