### PR TITLE
Fix intellij project import

### DIFF
--- a/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -8,16 +8,11 @@ import java.util.Arrays;
 import java.util.Properties;
 import lombok.Data;
 import lombok.SneakyThrows;
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -27,35 +22,8 @@ public class CcdSdkPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.getPlugins().apply(JavaPlugin.class);
 
-    // Write the zipped maven repo containing the generator to disk.
-    DirectoryProperty buildDir = project.getLayout().getBuildDirectory();
-    File archive = buildDir.file("generator.zip").get().getAsFile();
-    // Using a lambda here break's Gradle's up-to-date checks.
-    Task writeZip = project.getTasks().create("writeGenerator").doLast(new Action<Task>() {
-      @Override
-      @SneakyThrows
-      public void execute(Task task) {
-        try (InputStream is = CcdSdkPlugin.class.getClassLoader()
-            .getResourceAsStream("generator/generator.zip")) {
-          com.google.common.io.Files.createParentDirs(archive);
-          Files.copy(is, archive.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        }
-      }
-    });
-    writeZip.getOutputs().file(archive);
-
-    // Extract the local maven repo.
-    Copy unpackZip = project.getTasks().create("unpackGenerator", Copy.class);
-    unpackZip.dependsOn(writeZip);
-    unpackZip.from(project.zipTree(archive));
-    Provider<Directory> generatorDir =
-        buildDir.dir("generator");
-    unpackZip.into(generatorDir.get().getAsFile());
-
-    project.getTasks().getByName("compileJava").dependsOn(unpackZip);
-
-    // Add the repo to the project's repositories.
-    project.getRepositories().maven(x -> x.setUrl(generatorDir.get().getAsFile()));
+    // Extract the config generator maven repo and add to the project.
+    project.getRepositories().maven(x -> x.setUrl(extractGeneratorRepository(project)));
 
     // Add the dependency on the generator which will be fetched from the local maven repo.
     project.getDependencies().add("implementation", "com.github.hmcts:ccd-config-generator:"
@@ -81,6 +49,25 @@ public class CcdSdkPlugin implements Plugin<Project> {
     )));
 
     project.getRepositories().jcenter();
+  }
+
+  @SneakyThrows
+  private File extractGeneratorRepository(Project project) {
+    DirectoryProperty buildDir = project.getLayout().getBuildDirectory();
+    File archive = buildDir.file("generator.zip").get().getAsFile();
+    try (InputStream is = CcdSdkPlugin.class.getClassLoader()
+        .getResourceAsStream("generator/generator.zip")) {
+      com.google.common.io.Files.createParentDirs(archive);
+      Files.copy(is, archive.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    File generatorDir = buildDir.dir("config-generator-maven-repo").get().getAsFile();
+    project.copy(x -> {
+      x.from(project.zipTree(archive));
+      x.into(generatorDir);
+    });
+
+    return generatorDir;
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Change description ###

Fixes intellij project import by ensuring the config generator repository is always present for use by non-compilation tasks; config generator is now extracted in Gradle's configuration phase.





