### PR TITLE
Further trimming of obsolete functionality

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseFieldGenerator.java
@@ -49,7 +49,7 @@ class AuthorisationCaseFieldGenerator {
     Table<String, String, Set<Permission>> fieldRolePermissions = HashBasedTable.create();
     // Add field permissions based on event permissions.
     for (Event event : config.events) {
-      Map<R, Set<Permission>> eventPermissions = eventRolePermissions.row(event.getEventId());
+      Map<R, Set<Permission>> eventPermissions = eventRolePermissions.row(event.getId());
       List<Field.FieldBuilder> fields = event.getFields().build().getFields();
       for (Field.FieldBuilder fb : fields) {
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseFieldGenerator.java
@@ -49,7 +49,7 @@ class AuthorisationCaseFieldGenerator {
     Table<String, String, Set<Permission>> fieldRolePermissions = HashBasedTable.create();
     // Add field permissions based on event permissions.
     for (Event event : config.events) {
-      Map<R, Set<Permission>> eventPermissions = eventRolePermissions.row(event.getEventID());
+      Map<R, Set<Permission>> eventPermissions = eventRolePermissions.row(event.getEventId());
       List<Field.FieldBuilder> fields = event.getFields().build().getFields();
       for (Field.FieldBuilder fb : fields) {
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseStateGenerator.java
@@ -31,7 +31,7 @@ class AuthorisationCaseStateGenerator {
         continue;
       }
 
-      Map<R, Set<Permission>> rolePermissions = eventRolePermissions.row(event.getEventID());
+      Map<R, Set<Permission>> rolePermissions = eventRolePermissions.row(event.getEventId());
       for (Entry<R, Set<Permission>> rolePermission : rolePermissions.entrySet()) {
         // For state transitions if you have C then you get both states.
         // Otherwise you only need permission for the destination state.

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseStateGenerator.java
@@ -31,7 +31,7 @@ class AuthorisationCaseStateGenerator {
         continue;
       }
 
-      Map<R, Set<Permission>> rolePermissions = eventRolePermissions.row(event.getEventId());
+      Map<R, Set<Permission>> rolePermissions = eventRolePermissions.row(event.getId());
       for (Entry<R, Set<Permission>> rolePermission : rolePermissions.entrySet()) {
         // For state transitions if you have C then you get both states.
         // Otherwise you only need permission for the destination state.

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventGenerator.java
@@ -22,7 +22,7 @@ class CaseEventGenerator<T, S, R extends HasRole> {
     File folder = new File(root.getPath(), "CaseEvent");
     folder.mkdir();
     for (Event event : config.events) {
-      Path output = Paths.get(folder.getPath(), event.getId() + ".json");
+      Path output = Paths.get(folder.getPath(), event.getEventId() + ".json");
 
       JsonUtils.mergeInto(output, serialise(config.builder.caseType, event, config.allStates,
           config.builder.callbackHost),
@@ -34,7 +34,7 @@ class CaseEventGenerator<T, S, R extends HasRole> {
                                               Set<S> allStates, String callbackHost) {
     int t = 1;
     List result = Lists.newArrayList();
-    Map<String, Object> data = JsonUtils.getField(event.getId());
+    Map<String, Object> data = JsonUtils.getField(event.getEventId());
     result.add(data);
     data.put("Name", event.getName());
     data.put("Description", event.getDescription());

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventGenerator.java
@@ -22,7 +22,7 @@ class CaseEventGenerator<T, S, R extends HasRole> {
     File folder = new File(root.getPath(), "CaseEvent");
     folder.mkdir();
     for (Event event : config.events) {
-      Path output = Paths.get(folder.getPath(), event.getEventId() + ".json");
+      Path output = Paths.get(folder.getPath(), event.getId() + ".json");
 
       JsonUtils.mergeInto(output, serialise(config.builder.caseType, event, config.allStates,
           config.builder.callbackHost),
@@ -34,7 +34,7 @@ class CaseEventGenerator<T, S, R extends HasRole> {
                                               Set<S> allStates, String callbackHost) {
     int t = 1;
     List result = Lists.newArrayList();
-    Map<String, Object> data = JsonUtils.getField(event.getEventId());
+    Map<String, Object> data = JsonUtils.getField(event.getId());
     result.add(data);
     data.put("Name", event.getName());
     data.put("Description", event.getDescription());

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToComplexTypesGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToComplexTypesGenerator.java
@@ -23,14 +23,14 @@ class CaseEventToComplexTypesGenerator {
       FieldCollection collection = event.getFields().build();
       List<Map<String, Object>> entries = Lists.newArrayList();
       List<FieldCollection.FieldCollectionBuilder> complexFields = collection.getComplexFields();
-      expand(complexFields, entries, event.getEventId(), null, "");
+      expand(complexFields, entries, event.getId(), null, "");
 
       ImmutableListMultimap<String, Map<String, Object>> entriesByCaseField = Multimaps
           .index(entries, x -> x.get("CaseFieldID").toString());
 
       if (entriesByCaseField.size() > 0) {
         File folder = new File(String
-            .valueOf(Paths.get(root.getPath(), "CaseEventToComplexTypes", event.getEventId())));
+            .valueOf(Paths.get(root.getPath(), "CaseEventToComplexTypes", event.getId())));
         folder.mkdirs();
         for (String fieldID : entriesByCaseField.keySet()) {
           Path output = Paths.get(folder.getPath(), fieldID + event.getNamespace() + ".json");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToComplexTypesGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToComplexTypesGenerator.java
@@ -23,14 +23,14 @@ class CaseEventToComplexTypesGenerator {
       FieldCollection collection = event.getFields().build();
       List<Map<String, Object>> entries = Lists.newArrayList();
       List<FieldCollection.FieldCollectionBuilder> complexFields = collection.getComplexFields();
-      expand(complexFields, entries, event.getId(), null, "");
+      expand(complexFields, entries, event.getEventId(), null, "");
 
       ImmutableListMultimap<String, Map<String, Object>> entriesByCaseField = Multimaps
           .index(entries, x -> x.get("CaseFieldID").toString());
 
       if (entriesByCaseField.size() > 0) {
         File folder = new File(String
-            .valueOf(Paths.get(root.getPath(), "CaseEventToComplexTypes", event.getEventID())));
+            .valueOf(Paths.get(root.getPath(), "CaseEventToComplexTypes", event.getEventId())));
         folder.mkdirs();
         for (String fieldID : entriesByCaseField.keySet()) {
           Path output = Paths.get(folder.getPath(), fieldID + event.getNamespace() + ".json");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToFieldsGenerator.java
@@ -35,7 +35,7 @@ class CaseEventToFieldsGenerator {
           Map<String, Object> info = Maps.newHashMap();
           entries.add(info);
           info.put("LiveFrom", "01/01/2017");
-          info.put("CaseEventID", event.getId());
+          info.put("CaseEventID", event.getEventId());
           info.put("CaseTypeID", caseType);
           Field field = fb.build();
           info.put("CaseFieldID", field.getId());
@@ -59,10 +59,10 @@ class CaseEventToFieldsGenerator {
             info.put("FieldShowCondition", field.getShowCondition());
           }
 
-          if (midEventCallbacks.contains(event.getEventID(), pageId.toString())) {
+          if (midEventCallbacks.contains(event.getEventId(), pageId.toString())) {
             info.put("CallBackURLMidEvent", baseUrl + "/callbacks/mid-event?page="
                 + URLEncoder.encode(pageId.toString(), StandardCharsets.UTF_8));
-            midEventCallbacks.remove(event.getEventID(), pageId.toString());
+            midEventCallbacks.remove(event.getEventId(), pageId.toString());
           }
 
           if (collection.getPageShowConditions().containsKey(field.getPage())) {
@@ -86,7 +86,7 @@ class CaseEventToFieldsGenerator {
         File folder = new File(root.getPath(), "CaseEventToFields");
         folder.mkdir();
 
-        Path output = Paths.get(folder.getPath(), event.getId() + ".json");
+        Path output = Paths.get(folder.getPath(), event.getEventId() + ".json");
         JsonUtils.mergeInto(output, entries, new AddMissing(), "CaseFieldID");
       }
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseEventToFieldsGenerator.java
@@ -35,7 +35,7 @@ class CaseEventToFieldsGenerator {
           Map<String, Object> info = Maps.newHashMap();
           entries.add(info);
           info.put("LiveFrom", "01/01/2017");
-          info.put("CaseEventID", event.getEventId());
+          info.put("CaseEventID", event.getId());
           info.put("CaseTypeID", caseType);
           Field field = fb.build();
           info.put("CaseFieldID", field.getId());
@@ -59,10 +59,10 @@ class CaseEventToFieldsGenerator {
             info.put("FieldShowCondition", field.getShowCondition());
           }
 
-          if (midEventCallbacks.contains(event.getEventId(), pageId.toString())) {
+          if (midEventCallbacks.contains(event.getId(), pageId.toString())) {
             info.put("CallBackURLMidEvent", baseUrl + "/callbacks/mid-event?page="
                 + URLEncoder.encode(pageId.toString(), StandardCharsets.UTF_8));
-            midEventCallbacks.remove(event.getEventId(), pageId.toString());
+            midEventCallbacks.remove(event.getId(), pageId.toString());
           }
 
           if (collection.getPageShowConditions().containsKey(field.getPage())) {
@@ -86,7 +86,7 @@ class CaseEventToFieldsGenerator {
         File folder = new File(root.getPath(), "CaseEventToFields");
         folder.mkdir();
 
-        Path output = Paths.get(folder.getPath(), event.getEventId() + ".json");
+        Path output = Paths.get(folder.getPath(), event.getId() + ".json");
         JsonUtils.mergeInto(output, entries, new AddMissing(), "CaseFieldID");
       }
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.sdk;
 
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -17,14 +16,12 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.EventTypeBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Field;
-import uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
 import uk.gov.hmcts.ccd.sdk.api.RoleBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
-import uk.gov.hmcts.ccd.sdk.api.Webhook;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 
 public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, R> {
@@ -33,7 +30,6 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   public String caseType = "";
   public final SetMultimap<S, R> stateRoleHistoryAccess = HashMultimap.create();
   public final Table<S, R, Set<Permission>> stateRolePermissions = HashBasedTable.create();
-  public final Map<String, String> statePrefixes = Maps.newHashMap();
   public final Set<String> apiOnlyRoles = Sets.newHashSet();
   public final Map<String, List<Event.EventBuilder<T, R, S>>> events = Maps.newHashMap();
   public final List<Field.FieldBuilder> explicitFields = Lists.newArrayList();
@@ -52,12 +48,6 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   public String caseName = "";
   public String caseDesc = "";
   public String callbackHost;
-
-  private String defaultWebhookConvention(Webhook webhook, String eventId) {
-    eventId = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, eventId);
-    String path = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, webhook.toString());
-    return "/" + eventId + "/" + path;
-  }
 
   public ConfigBuilderImpl(Class caseData, Set<S> allStates) {
     this.caseData = caseData;
@@ -138,35 +128,6 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   }
 
   @Override
-  public void prefix(S state, String prefix) {
-    statePrefixes.put(state.toString(), prefix);
-  }
-
-  @Override
-  public FieldBuilder<?, ?, ?, ?> field(String id) {
-    FieldBuilder builder = FieldBuilder
-        .builder(caseData, null, id);
-    explicitFields.add(builder);
-    return builder;
-  }
-
-  @Override
-  public void caseField(String id, String showCondition, String type, String typeParam,
-                        String label) {
-    field(id).label(label).type(type).fieldTypeParameter(typeParam);
-  }
-
-  @Override
-  public void caseField(String id, String label, String type, String collectionType) {
-    caseField(id, null, type, collectionType, label);
-  }
-
-  @Override
-  public void caseField(String id, String label, String type) {
-    caseField(id, label, type, null);
-  }
-
-  @Override
   public TabBuilder<T, R> tab(String tabId, String tabLabel) {
     TabBuilder<T, R> result = Tab.TabBuilder.builder(caseData,
         new PropertyUtils()).tabID(tabId).label(tabLabel);
@@ -236,18 +197,6 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
     for (Map.Entry<String, List<Event.EventBuilder<T, R, S>>> cell : events.entrySet()) {
       for (Event.EventBuilder<T, R, S> builder : cell.getValue()) {
         Event<T, R, S> event = builder.build();
-        if (result.containsKey(event.getId())) {
-
-          S s = event.getPostState().iterator().next();
-          String namespace = statePrefixes.getOrDefault(s, "") + s;
-          String stateSpecificId =
-              event.getEventID() + namespace;
-          if (result.containsKey(stateSpecificId)) {
-            throw new RuntimeException("Duplicate event:" + stateSpecificId);
-          }
-          event.setId(stateSpecificId);
-          event.setNamespace(namespace);
-        }
         result.put(event.getId(), event);
       }
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -197,7 +197,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
     for (Map.Entry<String, List<Event.EventBuilder<T, R, S>>> cell : events.entrySet()) {
       for (Event.EventBuilder<T, R, S> builder : cell.getValue()) {
         Event<T, R, S> event = builder.build();
-        result.put(event.getId(), event);
+        result.put(event.getEventId(), event);
       }
     }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -197,7 +197,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
     for (Map.Entry<String, List<Event.EventBuilder<T, R, S>>> cell : events.entrySet()) {
       for (Event.EventBuilder<T, R, S> builder : cell.getValue()) {
         Event<T, R, S> event = builder.build();
-        result.put(event.getEventId(), event);
+        result.put(event.getId(), event);
       }
     }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
@@ -76,17 +76,17 @@ class ConfigGenerator<T, S, R extends HasRole> {
     Table<String, String, MidEvent> midEventCallbacks = HashBasedTable.create();
     for (Event event : events) {
       if (event.getAboutToStartCallback() != null) {
-        aboutToStartCallbacks.put(event.getEventId(), event.getAboutToStartCallback());
+        aboutToStartCallbacks.put(event.getId(), event.getAboutToStartCallback());
       }
       if (event.getAboutToSubmitCallback() != null) {
-        aboutToSubmitCallbacks.put(event.getEventId(), event.getAboutToSubmitCallback());
+        aboutToSubmitCallbacks.put(event.getId(), event.getAboutToSubmitCallback());
       }
       if (event.getSubmittedCallback() != null) {
-        submittedCallbacks.put(event.getEventId(), event.getSubmittedCallback());
+        submittedCallbacks.put(event.getId(), event.getSubmittedCallback());
       }
       for (Map.Entry<String, MidEvent> midEvent : event.getFields().build()
           .getPagesToMidEvent().entrySet()) {
-        midEventCallbacks.put(event.getEventId(), midEvent.getKey(), midEvent.getValue());
+        midEventCallbacks.put(event.getId(), midEvent.getKey(), midEvent.getValue());
       }
     }
 
@@ -203,7 +203,7 @@ class ConfigGenerator<T, S, R extends HasRole> {
         for (S key : keys) {
           Map<R, Set<Permission>> roles = builder.stateRolePermissions.row(key);
           for (R role : roles.keySet()) {
-            eventRolePermissions.put(event.getEventId(), role, roles.get(role));
+            eventRolePermissions.put(event.getId(), role, roles.get(role));
           }
         }
 
@@ -212,7 +212,7 @@ class ConfigGenerator<T, S, R extends HasRole> {
         for (S s : event.getPostState()) {
           if (stateRoleHistoryAccess.containsKey(s)) {
             for (R role : stateRoleHistoryAccess.get(s)) {
-              eventRolePermissions.put(event.getEventId(), role, Collections.singleton(Permission.R));
+              eventRolePermissions.put(event.getId(), role, Collections.singleton(Permission.R));
             }
           }
         }
@@ -220,7 +220,7 @@ class ConfigGenerator<T, S, R extends HasRole> {
       // Set event level permissions, overriding state level where set.
       SetMultimap<R, Permission> grants = event.getGrants();
       for (R role : grants.keySet()) {
-        eventRolePermissions.put(event.getEventId(), role,
+        eventRolePermissions.put(event.getId(), role,
             grants.get(role));
       }
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
@@ -76,17 +76,17 @@ class ConfigGenerator<T, S, R extends HasRole> {
     Table<String, String, MidEvent> midEventCallbacks = HashBasedTable.create();
     for (Event event : events) {
       if (event.getAboutToStartCallback() != null) {
-        aboutToStartCallbacks.put(event.getId(), event.getAboutToStartCallback());
+        aboutToStartCallbacks.put(event.getEventId(), event.getAboutToStartCallback());
       }
       if (event.getAboutToSubmitCallback() != null) {
-        aboutToSubmitCallbacks.put(event.getId(), event.getAboutToSubmitCallback());
+        aboutToSubmitCallbacks.put(event.getEventId(), event.getAboutToSubmitCallback());
       }
       if (event.getSubmittedCallback() != null) {
-        submittedCallbacks.put(event.getId(), event.getSubmittedCallback());
+        submittedCallbacks.put(event.getEventId(), event.getSubmittedCallback());
       }
       for (Map.Entry<String, MidEvent> midEvent : event.getFields().build()
           .getPagesToMidEvent().entrySet()) {
-        midEventCallbacks.put(event.getEventID(), midEvent.getKey(), midEvent.getValue());
+        midEventCallbacks.put(event.getEventId(), midEvent.getKey(), midEvent.getValue());
       }
     }
 
@@ -203,7 +203,7 @@ class ConfigGenerator<T, S, R extends HasRole> {
         for (S key : keys) {
           Map<R, Set<Permission>> roles = builder.stateRolePermissions.row(key);
           for (R role : roles.keySet()) {
-            eventRolePermissions.put(event.getId(), role, roles.get(role));
+            eventRolePermissions.put(event.getEventId(), role, roles.get(role));
           }
         }
 
@@ -212,7 +212,7 @@ class ConfigGenerator<T, S, R extends HasRole> {
         for (S s : event.getPostState()) {
           if (stateRoleHistoryAccess.containsKey(s)) {
             for (R role : stateRoleHistoryAccess.get(s)) {
-              eventRolePermissions.put(event.getId(), role, Collections.singleton(Permission.R));
+              eventRolePermissions.put(event.getEventId(), role, Collections.singleton(Permission.R));
             }
           }
         }
@@ -220,7 +220,7 @@ class ConfigGenerator<T, S, R extends HasRole> {
       // Set event level permissions, overriding state level where set.
       SetMultimap<R, Permission> grants = event.getGrants();
       for (R role : grants.keySet()) {
-        eventRolePermissions.put(event.getId(), role,
+        eventRolePermissions.put(event.getEventId(), role,
             grants.get(role));
       }
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.ccd.sdk.api;
 
 import java.util.Set;
-import uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
@@ -19,16 +18,6 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
   void grant(S state, Set<Permission> permissions, R... role);
 
   void grantHistory(S state, R... role);
-
-  void prefix(S state, String prefix);
-
-  FieldBuilder<?, ?, ?, ?> field(String id);
-
-  void caseField(String id, String showCondition, String type, String typeParam, String label);
-
-  void caseField(String id, String label, String type, String collectionType);
-
-  void caseField(String id, String label, String type);
 
   TabBuilder<T, R> tab(String tabId, String tabLabel);
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.ccd.sdk.api;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -126,13 +125,6 @@ public class Event<T, R extends HasRole, S> {
       this.explicitGrants = true;
       return this;
     }
-
-    EventBuilder<T, R, S> forState(S state) {
-      this.preState = Collections.singleton(state);
-      this.postState = Collections.singleton(state);
-      return this;
-    }
-
 
     public EventBuilder<T, R, S> grantHistoryOnly(R... roles) {
       for (R role : roles) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
 @Data
 public class Event<T, R extends HasRole, S> {
 
-  private String eventId;
+  private String id;
 
   private String name;
   private Set<S> preState;
@@ -70,7 +70,7 @@ public class Event<T, R extends HasRole, S> {
         String id, Class dataClass, PropertyUtils propertyUtils,
         Set<S> preStates, Set<S> postStates) {
       EventBuilder<T, R, S> result = new EventBuilder<T, R, S>();
-      result.eventId(id);
+      result.id(id);
       result.preState = preStates;
       result.postState = postStates;
       result.dataClass = dataClass;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Data;
 import lombok.ToString;
-import lombok.With;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
@@ -21,9 +20,6 @@ import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
 @Data
 public class Event<T, R extends HasRole, S> {
 
-  @With
-  private String id;
-  // The same event can have a different ID if on different states.
   private String eventId;
 
   private String name;
@@ -41,14 +37,6 @@ public class Event<T, R extends HasRole, S> {
   private AboutToStart<T, S> aboutToStartCallback;
   private AboutToSubmit<T, S> aboutToSubmitCallback;
   private Submitted<T, S> submittedCallback;
-
-  public void setEventID(String eventId) {
-    this.eventId = eventId;
-  }
-
-  public String getEventID() {
-    return this.eventId != null ? this.eventId : this.id;
-  }
 
   public void name(String s) {
     name = s;
@@ -82,7 +70,6 @@ public class Event<T, R extends HasRole, S> {
         String id, Class dataClass, PropertyUtils propertyUtils,
         Set<S> preStates, Set<S> postStates) {
       EventBuilder<T, R, S> result = new EventBuilder<T, R, S>();
-      result.id(id);
       result.eventId(id);
       result.preState = preStates;
       result.postState = postStates;


### PR DESCRIPTION
### Change description ###

Remove features now supported natively by CCD around events; events now have a single 'id' field.


