### PR TITLE
Money as int

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/MoneyGBP.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/MoneyGBP.java
@@ -14,4 +14,8 @@ import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 public class MoneyGBP {
 
   private final String amount;
+
+  public int toInt() {
+    return Integer.parseInt(amount);
+  }
 }


### PR DESCRIPTION
### Change description ###

Add toInt method to mask the fact that money is stored as a String.

