### PR TITLE
Remove inheritance of event permissions from states

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseFieldGenerator.java
@@ -57,10 +57,6 @@ class AuthorisationCaseFieldGenerator {
           if (event.getHistoryOnlyRoles().contains(rolePermission.getKey())) {
             continue;
           }
-          if (config.builder.stateRoleHistoryAccess.containsEntry(event.getPostState(),
-              rolePermission.getKey())) {
-            continue;
-          }
           Set<Permission> perm = fb.build().isImmutable()
               ? Permission.CR
               : rolePermission.getValue();

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/AuthorisationCaseStateGenerator.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.sdk;
 
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -22,10 +21,10 @@ import uk.gov.hmcts.ccd.sdk.api.Permission;
 class AuthorisationCaseStateGenerator {
 
   public static <T, S, R extends HasRole> void generate(
-      File root, ResolvedCCDConfig<T, S, R> config, Table<String, R,
-      Set<Permission>> eventRolePermissions) {
+      File root, ResolvedCCDConfig<T, S, R> config,
+      Table<String, R, Set<Permission>> eventRolePermissions,
+      Table<S, R, Set<Permission>> stateRolePermissions) {
 
-    Table<S, R, Set<Permission>> stateRolePermissions = HashBasedTable.create();
     for (Event<T, R, S> event : config.events) {
       if (event.getPreState().equals(config.allStates)) {
         continue;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.ccd.sdk;
 
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import java.util.Hashtable;
@@ -28,7 +26,6 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
   private final ImmutableSet<S> allStates;
   public String caseType = "";
-  public final SetMultimap<S, R> stateRoleHistoryAccess = HashMultimap.create();
   public final Table<S, R, Set<Permission>> stateRolePermissions = HashBasedTable.create();
   public final Set<String> apiOnlyRoles = Sets.newHashSet();
   public final Map<String, List<Event.EventBuilder<T, R, S>>> events = Maps.newHashMap();
@@ -117,13 +114,6 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   public void grant(S state, Set<Permission> permissions, R... roles) {
     for (R role : roles) {
       stateRolePermissions.put(state, role, permissions);
-    }
-  }
-
-  @Override
-  public void grantHistory(S state, R... roles) {
-    for (R role : roles) {
-      stateRoleHistoryAccess.put(state, role);
     }
   }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
@@ -113,7 +113,8 @@ class ConfigGenerator<T, S, R extends HasRole> {
     StateGenerator.generate(outputfolder, config.builder.caseType, config.stateArg);
     AuthorisationCaseTypeGenerator.generate(outputfolder, config.builder.caseType, config.roleType);
     CaseTypeTabGenerator.generate(outputfolder, config.builder.caseType, config.builder);
-    AuthorisationCaseStateGenerator.generate(outputfolder, config, eventPermissions);
+    AuthorisationCaseStateGenerator.generate(outputfolder, config, eventPermissions,
+        config.builder.stateRolePermissions);
     WorkBasketGenerator.generate(outputfolder, config.builder.caseType, config.builder);
     SearchFieldAndResultGenerator.generate(outputfolder, config.builder.caseType, config.builder);
     CaseRoleGenerator.generate(outputfolder, config.builder.caseType, config.roleType);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGenerator.java
@@ -196,17 +196,6 @@ class ConfigGenerator<T, S, R extends HasRole> {
     for (Event<T, R, S> event : events) {
       // Add any state based role permissions unless event permits only explicit grants.
       if (!event.isExplicitGrants()) {
-        // If Event is for all states, then apply each state's state level permissions.
-        Set<S> keys = event.getPreState().equals(allStates)
-            ? builder.stateRolePermissions.rowKeySet()
-            : event.getPostState();
-        for (S key : keys) {
-          Map<R, Set<Permission>> roles = builder.stateRolePermissions.row(key);
-          for (R role : roles.keySet()) {
-            eventRolePermissions.put(event.getId(), role, roles.get(role));
-          }
-        }
-
         // Add any case history access
         SetMultimap<S, R> stateRoleHistoryAccess = builder.stateRoleHistoryAccess;
         for (S s : event.getPostState()) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -15,6 +15,14 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
 
   void setEnvironment(String env);
 
+  /**
+   * Set AuthorisationCaseState explicitly.
+   * Note that additional AuthorisationCaseState permissions are inferred based on grants of
+   * event-level permissions.
+   * @param state state
+   * @param permissions permissions
+   * @param role One or more roles
+   */
   void grant(S state, Set<Permission> permissions, R... role);
 
   TabBuilder<T, R> tab(String tabId, String tabLabel);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -17,8 +17,6 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
 
   void grant(S state, Set<Permission> permissions, R... role);
 
-  void grantHistory(S state, R... role);
-
   TabBuilder<T, R> tab(String tabId, String tabLabel);
 
   WorkBasketBuilder<T, R> workBasketResultFields();

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -52,9 +52,6 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
     // Admin gets CRU on everything in Open state.
     builder.grant(Open, CRU, HMCTS_ADMIN);
 
-    // Local Authority can view the history of all events in the Open state.
-    builder.grantHistory(Open, LOCAL_AUTHORITY);
-
     // Describe the hierarchy of which roles go together.
     builder.role(CCD_SOLICITOR, CCD_LASOLICITOR).has(LOCAL_AUTHORITY);
     builder.role(JUDICIARY, GATEKEEPER).has(HMCTS_ADMIN);
@@ -76,6 +73,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
         .forStates(Gatekeeping, Submitted)
         .name("Add case notes")
         .grant(CRU, HMCTS_ADMIN)
+        .grant(R, LOCAL_AUTHORITY)
         .fields()
         .optional(CaseData::getCaseNotes);
   }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -75,6 +75,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
     builder.event("addNotes")
         .forStates(Gatekeeping, Submitted)
         .name("Add case notes")
+        .grant(CRU, HMCTS_ADMIN)
         .fields()
         .optional(CaseData::getCaseNotes);
   }
@@ -261,7 +262,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
         .initialState(Open)
         .name("Start application")
         .description("Create a new case – add a title")
-        .grant(CRU, LOCAL_AUTHORITY)
+        .grant(CRU, LOCAL_AUTHORITY, HMCTS_ADMIN)
         .aboutToSubmitCallback(this::aboutToSubmit)
         .submittedCallback(this::submitted)
         .retries(1,2,3,4,5)

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -19,6 +19,8 @@ import static uk.gov.hmcts.reform.fpl.enums.UserRole.JUDICIARY;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.LOCAL_AUTHORITY;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.SYSTEM_UPDATE;
 
+
+import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
@@ -49,8 +51,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
     builder.jurisdiction("PUBLICLAW", "Family Public Law", "Family Public Law desc");
     builder.caseType("CARE_SUPERVISION_EPO", "Care, supervision and EPOs", "Care, supervision and emergency protection orders");
 
-    // Admin gets CRU on everything in Open state.
-    builder.grant(Open, CRU, HMCTS_ADMIN);
+    builder.grant(Open, Set.of(R), LOCAL_AUTHORITY);
 
     // Describe the hierarchy of which roles go together.
     builder.role(CCD_SOLICITOR, CCD_LASOLICITOR).has(LOCAL_AUTHORITY);

--- a/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseState.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseState.json
@@ -47,5 +47,12 @@
     "LiveFrom": "01/01/2017",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CaseStateID": "PREPARE_FOR_HEARING"
+  },
+  {
+    "CRUD" : "R",
+    "CaseStateID" : "Open",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-solicitor"
   }
 ]


### PR DESCRIPTION
### Change description ###

ConfigBuilder.grant(State...) will now determine only AuthorisationCaseState and not cascade permissions to all events in the state.

Also removes some other unused permissions related functionality.

