### PR TITLE
Add support for state TitleDisplay

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseRoleGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/CaseRoleGenerator.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.ccd.sdk;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.ccd.sdk.JsonUtils.mergeInto;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
 import uk.gov.hmcts.ccd.sdk.JsonUtils.AddMissing;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 
 public class CaseRoleGenerator {
@@ -23,10 +26,28 @@ public class CaseRoleGenerator {
 
     final List<Map<String, Object>> caseRoles = Arrays.stream(roleClass.getEnumConstants())
         .filter(x -> ((HasRole)x).getRole().matches("^\\[.+\\]$"))
-        .map(o -> StateGenerator.enumToJsonMap(caseType, roleClass, o, ((HasRole) o).getRole()))
+        .map(o -> enumToJsonMap(caseType, roleClass, o, ((HasRole) o).getRole()))
         .collect(toList());
 
     mergeInto(path, caseRoles, new AddMissing(), "ID");
   }
 
+
+  @SneakyThrows
+  private static Map<String, Object> enumToJsonMap(String caseType, Class<?> enumType,
+                                                   Object enumConstant, String id) {
+    Map<String, Object> field = Maps.newHashMap();
+    field.put("LiveFrom", "01/01/2017");
+    field.put("CaseTypeID", caseType);
+    field.put("ID", id);
+
+    CCD ccd = enumType.getField(enumConstant.toString()).getAnnotation(CCD.class);
+    String name = ccd != null && !Strings.isNullOrEmpty(ccd.name()) ? ccd.name() :
+        enumConstant.toString();
+    String desc = ccd != null ? ccd.label() : "";
+    field.put("Name", name);
+    field.put("Description", desc);
+
+    return field;
+  }
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/StateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/StateGenerator.java
@@ -41,9 +41,13 @@ class StateGenerator {
     CCD ccd = enumType.getField(enumConstant.toString()).getAnnotation(CCD.class);
     String name = ccd != null && !Strings.isNullOrEmpty(ccd.name()) ? ccd.name() :
         enumConstant.toString();
-    String desc = ccd != null ? ccd.label() : "";
     field.put("Name", name);
-    field.put("Description", desc);
+    field.put("Description", name);
+    String desc = ccd != null ? ccd.label() : "";
+
+    if (!Strings.isNullOrEmpty(desc)) {
+      field.put("TitleDisplay", desc);
+    }
 
     return field;
   }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/State.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/State.java
@@ -3,15 +3,18 @@ package uk.gov.hmcts.reform.fpl.enums;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 
 public enum State {
-    @CCD(label = "Initial case state – create title as a minimum; add documents, etc.")
+    @CCD(name = "Initial case state – create title as a minimum; add documents, etc.")
     Open,
-    @CCD(label = "Submitted case state - LA can no longer edit")
+    @CCD(
+      name = "Submitted case state - LA can no longer edit",
+      label = "# **${[CASE_REFERENCE]}** ${applicant1LastName} **&** " +
+          "${applicant2LastName}\n" +
+          "### **${[STATE]}**\n")
     Submitted,
-    @CCD(label = "Gatekeeping case state - when send to gatekeeper event is triggered")
+    @CCD(name = "Gatekeeping case state - when send to gatekeeper event is triggered")
     Gatekeeping,
-    @CCD(name = "Prepare for hearing",
-        label = "State indicating that SDO is ready to send - triggered when SDO is issued")
+    @CCD(name = "State indicating that SDO is ready to send - triggered when SDO is issued")
     PREPARE_FOR_HEARING,
-    @CCD(label = "Deleted case state - all data is removed")
+    @CCD(name = "Deleted case state - all data is removed")
     Deleted
 }

--- a/ccd-config-generator/src/test/resources/ccd-definition/State.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/State.json
@@ -5,7 +5,7 @@
     "Description": "Initial case state – create title as a minimum; add documents, etc.",
     "DisplayOrder": 1,
     "ID": "Open",
-    "Name": "Open"
+    "Name": "Initial case state – create title as a minimum; add documents, etc."
   },
   {
     "LiveFrom": "01/01/2017",
@@ -13,7 +13,8 @@
     "Description": "Submitted case state - LA can no longer edit",
     "DisplayOrder": 2,
     "ID": "Submitted",
-    "Name": "Submitted"
+    "TitleDisplay" : "# **${[CASE_REFERENCE]}** ${applicant1LastName} **&** ${applicant2LastName}\n### **${[STATE]}**\n",
+    "Name": "Submitted case state - LA can no longer edit"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -21,7 +22,7 @@
     "Description": "Gatekeeping case state - when send to gatekeeper event is triggered",
     "DisplayOrder": 3,
     "ID": "Gatekeeping",
-    "Name": "Gatekeeping"
+    "Name": "Gatekeeping case state - when send to gatekeeper event is triggered"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -29,7 +30,7 @@
     "Description": "State indicating that SDO is ready to send - triggered when SDO is issued",
     "DisplayOrder": 4,
     "ID": "PREPARE_FOR_HEARING",
-    "Name": "Prepare for hearing"
+    "Name": "State indicating that SDO is ready to send - triggered when SDO is issued"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -37,6 +38,6 @@
     "Description": "Deleted case state - all data is removed",
     "DisplayOrder": 5,
     "ID": "Deleted",
-    "Name": "Deleted"
+    "Name": "Deleted case state - all data is removed"
   }
 ]


### PR DESCRIPTION
### Change description ###

Re-purpose the `@CCD` annotations label field to be used as the TitleDisplay for states. This means that the Name and Description of the state are always set to the value of the name field.


