### PR TITLE
Disable transitive dependency resolution for ccd client library

### DIFF
--- a/ccd-config-generator/build.gradle
+++ b/ccd-config-generator/build.gradle
@@ -19,7 +19,11 @@ dependencies {
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.20'
     implementation "org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    implementation group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.6'
+    implementation(group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.6') {
+        // The config generator needs only the types defined in the CCD client library,
+        // not all the runtime spring dependencies used by the CCD client.
+        transitive = false
+    }
 
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
     testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.20'


### PR DESCRIPTION
### Change description ###

The config generator only needs the types defined in the ccd client library, not the spring runtime dependencies.

This will fix the build failure for spring boot 2.5, which was caused by incompatibilities with the ccd transitive dependencies.





