### PR TITLE
Remove ConfigBuilderImpl from ResolvedCCDConfig

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -88,7 +88,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
       private Event.EventBuilder<T, R, S> build(Set<S> preStates, Set<S> postStates) {
         Event.EventBuilder<T, R, S> result = Event.EventBuilder
-            .builder(id, config.typeArg, new PropertyUtils(), preStates, postStates);
+            .builder(id, config.caseClass, new PropertyUtils(), preStates, postStates);
         if (!events.containsKey(id)) {
           events.put(id, Lists.newArrayList());
         }
@@ -121,7 +121,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
   @Override
   public TabBuilder<T, R> tab(String tabId, String tabLabel) {
-    TabBuilder<T, R> result = (TabBuilder<T, R>) TabBuilder.builder(config.typeArg,
+    TabBuilder<T, R> result = (TabBuilder<T, R>) TabBuilder.builder(config.caseClass,
         new PropertyUtils()).tabID(tabId).label(tabLabel);
     tabs.add(result);
     return result;
@@ -171,19 +171,19 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   }
 
   private WorkBasketBuilder getWorkBasketBuilder(List<WorkBasketBuilder> workBasketInputFields) {
-    WorkBasketBuilder result = WorkBasketBuilder.builder(config.typeArg, new PropertyUtils());
+    WorkBasketBuilder result = WorkBasketBuilder.builder(config.caseClass, new PropertyUtils());
     workBasketInputFields.add(result);
     return result;
   }
 
   private SearchBuilder getSearchBuilder(List<SearchBuilder> searchInputFields) {
-    SearchBuilder result = SearchBuilder.builder(config.typeArg, new PropertyUtils());
+    SearchBuilder result = SearchBuilder.builder(config.caseClass, new PropertyUtils());
     searchInputFields.add(result);
     return result;
   }
 
   private SearchCasesBuilder getSearchCasesBuilder(List<SearchCasesBuilder> searchInputFields) {
-    SearchCasesBuilder result = SearchCasesBuilder.builder(config.typeArg, new PropertyUtils());
+    SearchCasesBuilder result = SearchCasesBuilder.builder(config.caseClass, new PropertyUtils());
     searchInputFields.add(result);
     return result;
   }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -1,54 +1,56 @@
 package uk.gov.hmcts.ccd.sdk;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Table;
+import java.util.Collection;
 import java.util.EnumSet;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.EventTypeBuilder;
-import uk.gov.hmcts.ccd.sdk.api.Field;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
 import uk.gov.hmcts.ccd.sdk.api.RoleBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.SearchCases.SearchCasesBuilder;
-import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 
 public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, R> {
 
-  private final ImmutableSet<S> allStates;
-  public String caseType = "default";
-  public final Table<S, R, Set<Permission>> stateRolePermissions = HashBasedTable.create();
-  public final Map<String, List<Event.EventBuilder<T, R, S>>> events = Maps.newHashMap();
-  public final List<Field.FieldBuilder> explicitFields = Lists.newArrayList();
-  public final List<TabBuilder<T, R>> tabs = Lists.newArrayList();
-  public final List<WorkBasketBuilder> workBasketResultFields = Lists.newArrayList();
-  public final List<WorkBasketBuilder> workBasketInputFields = Lists.newArrayList();
-  public final List<SearchBuilder> searchResultFields = Lists.newArrayList();
-  public final List<SearchBuilder> searchInputFields = Lists.newArrayList();
-  public final List<SearchCasesBuilder> searchCaseResultFields = Lists.newArrayList();
-  public final Map<String, String> roleHierarchy = new Hashtable<>();
+  private final ResolvedCCDConfig<T, S, R> config;
 
-  private Class caseData;
-  public String jurId = "";
-  public String jurName = "";
-  public String jurDesc = "";
-  public String caseName = "";
-  public String caseDesc = "";
-  public String callbackHost;
+  final Map<String, List<Event.EventBuilder<T, R, S>>> events = Maps.newHashMap();
+  final List<TabBuilder<T, R>> tabs = Lists.newArrayList();
+  final List<WorkBasketBuilder> workBasketResultFields = Lists.newArrayList();
+  final List<WorkBasketBuilder> workBasketInputFields = Lists.newArrayList();
+  final List<SearchBuilder> searchResultFields = Lists.newArrayList();
+  final List<SearchBuilder> searchInputFields = Lists.newArrayList();
+  final List<SearchCasesBuilder> searchCaseResultFields = Lists.newArrayList();
 
-  public ConfigBuilderImpl(Class caseData, Set<S> allStates) {
-    this.caseData = caseData;
-    this.allStates = ImmutableSet.copyOf(allStates);
+  public ConfigBuilderImpl(ResolvedCCDConfig<T, S, R> config) {
+    this.config = config;
+  }
+
+  <X, Y> List<Y> buildBuilders(Collection<X> c, Function<X, Y> f) {
+    return c.stream().map(f).collect(Collectors.toList());
+  }
+
+  public ResolvedCCDConfig<T, S, R> build() {
+    config.events = getEvents();
+    config.tabs = buildBuilders(tabs, TabBuilder::build);
+    config.workBasketResultFields = buildBuilders(workBasketResultFields, WorkBasketBuilder::build);
+    config.workBasketInputFields = buildBuilders(workBasketInputFields, WorkBasketBuilder::build);
+    config.searchResultFields = buildBuilders(searchResultFields, SearchBuilder::build);
+    config.searchInputFields = buildBuilders(searchInputFields, SearchBuilder::build);
+    config.searchCaseResultFields = buildBuilders(searchCaseResultFields, SearchCasesBuilder::build);
+
+    return config;
   }
 
   @Override
@@ -76,17 +78,17 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
       @Override
       public Event.EventBuilder<T, R, S> forAllStates() {
-        return build(allStates, allStates);
+        return build(config.allStates, config.allStates);
       }
 
       @Override
       public Event.EventBuilder<T, R, S> forStates(S... states) {
-        return build(Set.of(states), allStates);
+        return build(Set.of(states), config.allStates);
       }
 
       private Event.EventBuilder<T, R, S> build(Set<S> preStates, Set<S> postStates) {
         Event.EventBuilder<T, R, S> result = Event.EventBuilder
-            .builder(id, caseData, new PropertyUtils(), preStates, postStates);
+            .builder(id, config.typeArg, new PropertyUtils(), preStates, postStates);
         if (!events.containsKey(id)) {
           events.put(id, Lists.newArrayList());
         }
@@ -98,28 +100,28 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
   @Override
   public void caseType(String caseType, String name, String desc) {
-    this.caseType = caseType;
-    this.caseName = name;
-    this.caseDesc = desc;
+    config.caseType = caseType;
+    config.caseName = name;
+    config.caseDesc = desc;
   }
 
   @Override
   public void jurisdiction(String id, String name, String description) {
-    this.jurId = id;
-    this.jurName = name;
-    this.jurDesc = description;
+    config.jurId = id;
+    config.jurName = name;
+    config.jurDesc = description;
   }
 
   @Override
   public void grant(S state, Set<Permission> permissions, R... roles) {
     for (R role : roles) {
-      stateRolePermissions.put(state, role, permissions);
+      config.stateRolePermissions.put(state, role, permissions);
     }
   }
 
   @Override
   public TabBuilder<T, R> tab(String tabId, String tabLabel) {
-    TabBuilder<T, R> result = Tab.TabBuilder.builder(caseData,
+    TabBuilder<T, R> result = (TabBuilder<T, R>) TabBuilder.builder(config.typeArg,
         new PropertyUtils()).tabID(tabId).label(tabLabel);
     tabs.add(result);
     return result;
@@ -157,7 +159,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
       @Override
       public void has(R parent) {
         for (R role : roles) {
-          roleHierarchy.put(role.getRole(), parent.getRole());
+          config.roleHierarchy.put(role.getRole(), parent.getRole());
         }
       }
     };
@@ -165,28 +167,28 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
   @Override
   public void setCallbackHost(String s) {
-    this.callbackHost = s;
+    config.callbackHost = s;
   }
 
   private WorkBasketBuilder getWorkBasketBuilder(List<WorkBasketBuilder> workBasketInputFields) {
-    WorkBasketBuilder result = WorkBasketBuilder.builder(caseData, new PropertyUtils());
+    WorkBasketBuilder result = WorkBasketBuilder.builder(config.typeArg, new PropertyUtils());
     workBasketInputFields.add(result);
     return result;
   }
 
   private SearchBuilder getSearchBuilder(List<SearchBuilder> searchInputFields) {
-    SearchBuilder result = SearchBuilder.builder(caseData, new PropertyUtils());
+    SearchBuilder result = SearchBuilder.builder(config.typeArg, new PropertyUtils());
     searchInputFields.add(result);
     return result;
   }
 
   private SearchCasesBuilder getSearchCasesBuilder(List<SearchCasesBuilder> searchInputFields) {
-    SearchCasesBuilder result = SearchCasesBuilder.builder(caseData, new PropertyUtils());
+    SearchCasesBuilder result = SearchCasesBuilder.builder(config.typeArg, new PropertyUtils());
     searchInputFields.add(result);
     return result;
   }
 
-  public List<Event<T, R, S>> getEvents() {
+  ImmutableMap<String, Event<T, R, S>> getEvents() {
     Map<String, Event<T, R, S>> result = Maps.newHashMap();
     for (Map.Entry<String, List<Event.EventBuilder<T, R, S>>> cell : events.entrySet()) {
       for (Event.EventBuilder<T, R, S> builder : cell.getValue()) {
@@ -195,7 +197,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
       }
     }
 
-    return Lists.newArrayList(result.values());
+    return ImmutableMap.copyOf(result);
   }
 
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.ccd.sdk.api.SearchCases.SearchCasesBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 
-public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, R> {
+class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, R> {
 
   private final ResolvedCCDConfig<T, S, R> config;
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -190,7 +190,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
     Map<String, Event<T, R, S>> result = Maps.newHashMap();
     for (Map.Entry<String, List<Event.EventBuilder<T, R, S>>> cell : events.entrySet()) {
       for (Event.EventBuilder<T, R, S> builder : cell.getValue()) {
-        Event<T, R, S> event = builder.build();
+        Event<T, R, S> event = builder.doBuild();
         result.put(event.getId(), event);
       }
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigResolver.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigResolver.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ccd.sdk;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
@@ -19,6 +20,7 @@ import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Search;
+import uk.gov.hmcts.ccd.sdk.api.SearchCases;
 import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
@@ -72,7 +74,9 @@ class ConfigResolver<T, S, R extends HasRole> {
     }
 
     Map<Class, Integer> types = resolve(typeArgs[0], basePackage);
-    return new ResolvedCCDConfig(builder.caseType, typeArgs[0], typeArgs[1], typeArgs[2], builder, events, types,
+    return new ResolvedCCDConfig(builder.caseType, builder.callbackHost, builder.caseName,
+        builder.caseDesc, builder.jurId, builder.jurName, builder.jurDesc,
+        typeArgs[0], typeArgs[1], typeArgs[2], events, types,
         allStates, aboutToStartCallbacks, aboutToSubmitCallbacks, submittedCallbacks,
         midEventCallbacks, builder.stateRolePermissions,
         builder.tabs.stream().map(Tab.TabBuilder::build).collect(Collectors.toList()),
@@ -83,6 +87,11 @@ class ConfigResolver<T, S, R extends HasRole> {
         builder.searchResultFields.stream().map(Search.SearchBuilder::build).collect(
             Collectors.toList()),
         builder.searchInputFields.stream().map(Search.SearchBuilder::build).collect(
+            Collectors.toList()),
+        builder.searchCaseResultFields.stream().map(SearchCases.SearchCasesBuilder::build).collect(
+            Collectors.toList()),
+        ImmutableMap.copyOf(builder.roleHierarchy),
+        builder.explicitFields.stream().map(uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder::build).collect(
             Collectors.toList())
         );
   }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigResolver.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigResolver.java
@@ -70,7 +70,7 @@ class ConfigResolver<T, S, R extends HasRole> {
     Map<Class, Integer> types = resolve(typeArgs[0], basePackage);
     return new ResolvedCCDConfig(builder.caseType, typeArgs[0], typeArgs[1], typeArgs[2], builder, events, types,
         allStates, aboutToStartCallbacks, aboutToSubmitCallbacks, submittedCallbacks,
-        midEventCallbacks);
+        midEventCallbacks, builder.stateRolePermissions);
   }
 
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.sdk;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 import java.util.List;
@@ -7,9 +8,11 @@ import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.Field;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
 import uk.gov.hmcts.ccd.sdk.api.Search;
+import uk.gov.hmcts.ccd.sdk.api.SearchCases;
 import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
@@ -21,10 +24,15 @@ import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
 public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
   public final String caseType;
+  public final String callbackHost;
+  public final String caseName;
+  public final String caseDesc;
+  public final String jurId;
+  public final String jurName;
+  public final String jurDesc;
   public final Class<?> typeArg;
   public final Class<S> stateArg;
   public final Class<?> roleType;
-  public final ConfigBuilderImpl<T, S, R> builder;
   public final List<Event<T, R, S>> events;
   public final Map<Class, Integer> types;
   public final ImmutableSet<S> allStates;
@@ -39,4 +47,7 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
   public final List<WorkBasket> workBasketInputFields;
   public final List<Search> searchResultFields;
   public final List<Search> searchInputFields;
+  public final List<SearchCases> searchCaseResultFields;
+  public final ImmutableMap<String, String> roleHierarchy;
+  public final List<Field> explicitFields;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.ccd.sdk;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Map;
@@ -10,7 +12,6 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import uk.gov.hmcts.ccd.sdk.api.Event;
-import uk.gov.hmcts.ccd.sdk.api.Field;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
 import uk.gov.hmcts.ccd.sdk.api.Search;
@@ -19,30 +20,32 @@ import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 
 @RequiredArgsConstructor
-@FieldDefaults(makeFinal = true, level = AccessLevel.PUBLIC)
+@FieldDefaults(level = AccessLevel.PUBLIC)
 public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
-  String caseType;
-  String callbackHost;
-  String caseName;
-  String caseDesc;
-  String jurId;
-  String jurName;
-  String jurDesc;
-  Class<?> typeArg;
-  Class<S> stateArg;
-  Class<?> roleType;
+  final Class<?> typeArg;
+  final Class<S> stateArg;
+  final Class<?> roleType;
+  final Map<Class, Integer> types;
+  final ImmutableSet<S> allStates;
+
+  String caseType = "";
+  String callbackHost = "";
+  String caseName = "";
+  String caseDesc = "";
+  String jurId = "";
+  String jurName = "";
+  String jurDesc = "";
+
+  Table<S, R, Set<Permission>> stateRolePermissions = HashBasedTable.create();
+  Map<String, String> roleHierarchy = Maps.newHashMap();
+
   // Events by id
   ImmutableMap<String, Event<T, R, S>> events;
-  Map<Class, Integer> types;
-  ImmutableSet<S> allStates;
-  Table<S, R, Set<Permission>> stateRolePermissions;
   List<Tab<T, R>> tabs;
   List<WorkBasket> workBasketResultFields;
   List<WorkBasket> workBasketInputFields;
   List<Search> searchResultFields;
   List<Search> searchInputFields;
   List<SearchCases> searchCaseResultFields;
-  ImmutableMap<String, String> roleHierarchy;
-  List<Field> explicitFields;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -23,9 +23,9 @@ import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 @FieldDefaults(level = AccessLevel.PUBLIC)
 public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
-  final Class<?> typeArg;
-  final Class<S> stateArg;
-  final Class<?> roleType;
+  final Class<T> caseClass;
+  final Class<S> stateClass;
+  final Class<R> roleClass;
   final Map<Class, Integer> types;
   final ImmutableSet<S> allStates;
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -15,10 +15,6 @@ import uk.gov.hmcts.ccd.sdk.api.Search;
 import uk.gov.hmcts.ccd.sdk.api.SearchCases;
 import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
-import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
-import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
-import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
-import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
 
 @RequiredArgsConstructor
 public class ResolvedCCDConfig<T, S, R extends HasRole> {
@@ -33,14 +29,10 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
   public final Class<?> typeArg;
   public final Class<S> stateArg;
   public final Class<?> roleType;
-  public final List<Event<T, R, S>> events;
+  // Events by id
+  public final ImmutableMap<String, Event<T, R, S>> events;
   public final Map<Class, Integer> types;
   public final ImmutableSet<S> allStates;
-  public final Map<String, AboutToStart<T, S>> aboutToStartCallbacks;
-  public final Map<String, AboutToSubmit<T, S>> aboutToSubmitCallbacks;
-  public final Map<String, Submitted<T, S>> submittedCallbacks;
-  // Maps event ID and page ID to mid-event callbacks
-  public final Table<String, String, MidEvent<T, S>> midEventCallbacks;
   public final Table<S, R, Set<Permission>> stateRolePermissions;
   public final List<Tab<T, R>> tabs;
   public final List<WorkBasket> workBasketResultFields;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -4,9 +4,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
+import uk.gov.hmcts.ccd.sdk.api.Permission;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
@@ -28,4 +30,5 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
   public final Map<String, Submitted<T, S>> submittedCallbacks;
   // Maps event ID and page ID to mid-event callbacks
   public final Table<String, String, MidEvent<T, S>> midEventCallbacks;
+  public final Table<S, R, Set<Permission>> stateRolePermissions;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -8,9 +8,8 @@ import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.experimental.FieldDefaults;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
@@ -20,7 +19,7 @@ import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 
 @RequiredArgsConstructor
-@FieldDefaults(level = AccessLevel.PUBLIC)
+@Getter
 public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
   final Class<T> caseClass;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.ccd.sdk.api.Search;
+import uk.gov.hmcts.ccd.sdk.api.Tab;
+import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
@@ -31,4 +34,9 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
   // Maps event ID and page ID to mid-event callbacks
   public final Table<String, String, MidEvent<T, S>> midEventCallbacks;
   public final Table<S, R, Set<Permission>> stateRolePermissions;
+  public final List<Tab<T, R>> tabs;
+  public final List<WorkBasket> workBasketResultFields;
+  public final List<WorkBasket> workBasketInputFields;
+  public final List<Search> searchResultFields;
+  public final List<Search> searchInputFields;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -6,7 +6,9 @@ import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.Field;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
@@ -17,29 +19,30 @@ import uk.gov.hmcts.ccd.sdk.api.Tab;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 
 @RequiredArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PUBLIC)
 public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
-  public final String caseType;
-  public final String callbackHost;
-  public final String caseName;
-  public final String caseDesc;
-  public final String jurId;
-  public final String jurName;
-  public final String jurDesc;
-  public final Class<?> typeArg;
-  public final Class<S> stateArg;
-  public final Class<?> roleType;
+  String caseType;
+  String callbackHost;
+  String caseName;
+  String caseDesc;
+  String jurId;
+  String jurName;
+  String jurDesc;
+  Class<?> typeArg;
+  Class<S> stateArg;
+  Class<?> roleType;
   // Events by id
-  public final ImmutableMap<String, Event<T, R, S>> events;
-  public final Map<Class, Integer> types;
-  public final ImmutableSet<S> allStates;
-  public final Table<S, R, Set<Permission>> stateRolePermissions;
-  public final List<Tab<T, R>> tabs;
-  public final List<WorkBasket> workBasketResultFields;
-  public final List<WorkBasket> workBasketInputFields;
-  public final List<Search> searchResultFields;
-  public final List<Search> searchInputFields;
-  public final List<SearchCases> searchCaseResultFields;
-  public final ImmutableMap<String, String> roleHierarchy;
-  public final List<Field> explicitFields;
+  ImmutableMap<String, Event<T, R, S>> events;
+  Map<Class, Integer> types;
+  ImmutableSet<S> allStates;
+  Table<S, R, Set<Permission>> stateRolePermissions;
+  List<Tab<T, R>> tabs;
+  List<WorkBasket> workBasketResultFields;
+  List<WorkBasket> workBasketInputFields;
+  List<Search> searchResultFields;
+  List<Search> searchInputFields;
+  List<SearchCases> searchCaseResultFields;
+  ImmutableMap<String, String> roleHierarchy;
+  List<Field> explicitFields;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -81,6 +81,7 @@ public class Event<T, R extends HasRole, S> {
 
     public Event<T, R, S> doBuild() {
       Event<T, R, S> result = build();
+      // Complete the building of the nested builder.
       result.fields = fieldsBuilder.build();
       return result;
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Data;
-import lombok.ToString;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
@@ -33,6 +32,7 @@ public class Event<T, R extends HasRole, S> {
   private AboutToStart<T, S> aboutToStartCallback;
   private AboutToSubmit<T, S> aboutToSubmitCallback;
   private Submitted<T, S> submittedCallback;
+  private FieldCollection fields;
 
   public void name(String s) {
     name = s;
@@ -41,8 +41,6 @@ public class Event<T, R extends HasRole, S> {
     }
   }
 
-  @ToString.Exclude
-  private FieldCollection.FieldCollectionBuilder<T, S, EventBuilder<T, R, S>> fields;
 
   @Builder.Default
   // TODO: don't always add.
@@ -62,6 +60,8 @@ public class Event<T, R extends HasRole, S> {
 
   public static class EventBuilder<T, R extends HasRole, S> {
 
+    private FieldCollection.FieldCollectionBuilder<T, S, EventBuilder<T, R, S>> fieldsBuilder;
+
     public static <T, R extends HasRole, S> EventBuilder<T, R, S> builder(
         String id, Class dataClass, PropertyUtils propertyUtils,
         Set<S> preStates, Set<S> postStates) {
@@ -72,15 +72,21 @@ public class Event<T, R extends HasRole, S> {
       result.dataClass = dataClass;
       result.grants = HashMultimap.create();
       result.historyOnlyRoles = new HashSet<>();
-      result.fields = FieldCollection.FieldCollectionBuilder
+      result.fieldsBuilder = FieldCollection.FieldCollectionBuilder
           .builder(result, result, dataClass, propertyUtils);
       result.retries = new HashMap<>();
 
       return result;
     }
 
+    public Event<T, R, S> doBuild() {
+      Event<T, R, S> result = build();
+      result.fields = fieldsBuilder.build();
+      return result;
+    }
+
     public FieldCollection.FieldCollectionBuilder<T, S, EventBuilder<T, R, S>> fields() {
-      return fields;
+      return fieldsBuilder;
     }
 
     public EventBuilder<T, R, S> name(String n) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseEventGenerator.java
@@ -20,7 +20,7 @@ class AuthorisationCaseEventGenerator<T, S, R extends HasRole> implements Config
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
     List<Map<String, Object>> entries = Lists.newArrayList();
 
-    for (Event<T, R, S> event : config.events) {
+    for (Event<T, R, S> event : config.events.values()) {
       for (R role : event.getGrants().keys()) {
         Map<String, Object> entry = Maps.newHashMap();
         entries.add(entry);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseEventGenerator.java
@@ -20,12 +20,12 @@ class AuthorisationCaseEventGenerator<T, S, R extends HasRole> implements Config
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
     List<Map<String, Object>> entries = Lists.newArrayList();
 
-    for (Event<T, R, S> event : config.events.values()) {
+    for (Event<T, R, S> event : config.getEvents().values()) {
       for (R role : event.getGrants().keys()) {
         Map<String, Object> entry = Maps.newHashMap();
         entries.add(entry);
         entry.put("LiveFrom", "01/01/2017");
-        entry.put("CaseTypeID", config.caseType);
+        entry.put("CaseTypeID", config.getCaseType());
         entry.put("CaseEventID", event.getId());
         entry.put("UserRole", role.getRole());
         entry.put("CRUD", Permission.toString(event.getGrants().get(role)));

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
@@ -51,7 +51,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
     Table<String, String, Set<Permission>> fieldRolePermissions = HashBasedTable.create();
     // Add field permissions based on event permissions.
-    for (Event<T, R, S> event : config.events.values()) {
+    for (Event<T, R, S> event : config.getEvents().values()) {
       List<Field.FieldBuilder> fields = event.getFields().getFields();
       for (Field.FieldBuilder fb : fields) {
 
@@ -83,7 +83,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
       fieldRolePermissions.put("caseHistory", role, CRU);
 
       // Add read for any tab fields
-      for (Tab<T, R> tab : config.tabs) {
+      for (Tab<T, R> tab : config.getTabs()) {
         for (TabField field : tab.getFields()) {
           boolean giveReadPermission = tab.getRorRolesAsString().contains(role) || tab.getForRoles().isEmpty();
           if (giveReadPermission && !fieldRolePermissions.contains(field.getId(), role)) {
@@ -94,8 +94,8 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
       // Add read for WorkBaskets
       for (WorkBasket basket :
-          Iterables.concat(config.workBasketInputFields,
-              config.workBasketResultFields)) {
+          Iterables.concat(config.getWorkBasketInputFields(),
+              config.getWorkBasketResultFields())) {
         for (WorkBasketField field : basket.getFields()) {
           if (!fieldRolePermissions.contains(field.getId(), role)) {
             fieldRolePermissions.put(field.getId(), role, Collections.singleton(Permission.R));
@@ -105,8 +105,8 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
       // Add read for Search Input fields
       for (Search search :
-          Iterables.concat(config.searchInputFields,
-              config.searchResultFields)) {
+          Iterables.concat(config.getSearchInputFields(),
+              config.getSearchResultFields())) {
         for (SearchField field : search.getFields()) {
           if (!fieldRolePermissions.contains(field.getId(), role)) {
             fieldRolePermissions.put(field.getId(), role, Collections.singleton(Permission.R));
@@ -115,7 +115,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
       }
     }
 
-    addPermissionsFromFields(fieldRolePermissions, config.caseClass, null, null);
+    addPermissionsFromFields(fieldRolePermissions, config.getCaseClass(), null, null);
 
     File folder = new File(root.getPath(), "AuthorisationCaseField");
     folder.mkdir();
@@ -130,7 +130,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
         String field = fieldPerm.getKey();
         Set<Permission> inheritedPermission = getInheritedPermission(fieldRolePermissions,
-            config.roleHierarchy, role, field);
+            config.getRoleHierarchy(), role, field);
         Set<Permission> fieldPermission = fieldPerm.getValue();
         if (inheritedPermission != null) {
           Set<Permission> newPermissions = Sets.newHashSet(fieldPerm.getValue());
@@ -143,13 +143,13 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
             continue;
           }
           Map<String, Object> permission = new Hashtable<>();
-          permission.put("CaseTypeID", config.caseType);
+          permission.put("CaseTypeID", config.getCaseType());
           permission.put("LiveFrom", "01/01/2017");
           permission.put("UserRole", role);
           permission.put("CaseFieldID", field);
           permission.put("CRUD", Permission.toString(fieldPermission));
 
-          Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.caseClass, field);
+          Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.getCaseClass(), field);
 
           if (unwrapped.isEmpty()) {
             permissions.add(permission);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
@@ -130,7 +130,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
         String field = fieldPerm.getKey();
         Set<Permission> inheritedPermission = getInheritedPermission(fieldRolePermissions,
-            config.builder.roleHierarchy, role, field);
+            config.roleHierarchy, role, field);
         Set<Permission> fieldPermission = fieldPerm.getValue();
         if (inheritedPermission != null) {
           Set<Permission> newPermissions = Sets.newHashSet(fieldPerm.getValue());

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
@@ -115,7 +115,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
       }
     }
 
-    addPermissionsFromFields(fieldRolePermissions, config.typeArg, null, null);
+    addPermissionsFromFields(fieldRolePermissions, config.caseClass, null, null);
 
     File folder = new File(root.getPath(), "AuthorisationCaseField");
     folder.mkdir();
@@ -149,7 +149,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
           permission.put("CaseFieldID", field);
           permission.put("CRUD", Permission.toString(fieldPermission));
 
-          Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.typeArg, field);
+          Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.caseClass, field);
 
           if (unwrapped.isEmpty()) {
             permissions.add(permission);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
@@ -51,8 +51,8 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
     Table<String, String, Set<Permission>> fieldRolePermissions = HashBasedTable.create();
     // Add field permissions based on event permissions.
-    for (Event<T, R, S> event : config.events) {
-      List<Field.FieldBuilder> fields = event.getFields().build().getFields();
+    for (Event<T, R, S> event : config.events.values()) {
+      List<Field.FieldBuilder> fields = event.getFields().getFields();
       for (Field.FieldBuilder fb : fields) {
 
         for (R role : event.getGrants().keys()) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
@@ -37,13 +37,10 @@ import uk.gov.hmcts.ccd.sdk.api.HasAccessControl;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
 import uk.gov.hmcts.ccd.sdk.api.Search;
-import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.SearchField;
 import uk.gov.hmcts.ccd.sdk.api.Tab;
-import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
 import uk.gov.hmcts.ccd.sdk.api.TabField;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
-import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasketField;
 
 @Component
@@ -86,8 +83,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
       fieldRolePermissions.put("caseHistory", role, CRU);
 
       // Add read for any tab fields
-      for (TabBuilder<T, R> tb : config.builder.tabs) {
-        Tab<T, R> tab = tb.build();
+      for (Tab<T, R> tab : config.tabs) {
         for (TabField field : tab.getFields()) {
           boolean giveReadPermission = tab.getRorRolesAsString().contains(role) || tab.getForRoles().isEmpty();
           if (giveReadPermission && !fieldRolePermissions.contains(field.getId(), role)) {
@@ -97,10 +93,9 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
       }
 
       // Add read for WorkBaskets
-      for (WorkBasketBuilder workBasketInputField :
-          Iterables.concat(config.builder.workBasketInputFields,
-              config.builder.workBasketResultFields)) {
-        WorkBasket basket = workBasketInputField.build();
+      for (WorkBasket basket :
+          Iterables.concat(config.workBasketInputFields,
+              config.workBasketResultFields)) {
         for (WorkBasketField field : basket.getFields()) {
           if (!fieldRolePermissions.contains(field.getId(), role)) {
             fieldRolePermissions.put(field.getId(), role, Collections.singleton(Permission.R));
@@ -109,10 +104,9 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
       }
 
       // Add read for Search Input fields
-      for (SearchBuilder searchInputField :
-          Iterables.concat(config.builder.searchInputFields,
-              config.builder.searchResultFields)) {
-        Search search = searchInputField.build();
+      for (Search search :
+          Iterables.concat(config.searchInputFields,
+              config.searchResultFields)) {
         for (SearchField field : search.getFields()) {
           if (!fieldRolePermissions.contains(field.getId(), role)) {
             fieldRolePermissions.put(field.getId(), role, Collections.singleton(Permission.R));
@@ -149,7 +143,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
             continue;
           }
           Map<String, Object> permission = new Hashtable<>();
-          permission.put("CaseTypeID", config.builder.caseType);
+          permission.put("CaseTypeID", config.caseType);
           permission.put("LiveFrom", "01/01/2017");
           permission.put("UserRole", role);
           permission.put("CaseFieldID", field);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
@@ -41,14 +41,14 @@ class AuthorisationCaseStateGenerator<T, S, R extends HasRole> implements Config
         // Otherwise you only need permission for the destination state.
         if (event.getPreState() != event.getPostState()) {
           if (grants.get(role).contains(Permission.C) && !event.getPreState().isEmpty()) {
-            addPermissions(config.builder.stateRolePermissions, event.getPreState(), role,
+            addPermissions(config.stateRolePermissions, event.getPreState(), role,
                 grants.get(role));
             // They get R only on the destination state.
-            addPermissions(config.builder.stateRolePermissions, event.getPostState(), role,
+            addPermissions(config.stateRolePermissions, event.getPostState(), role,
                 Collections.singleton(Permission.R));
           }
         } else {
-          addPermissions(config.builder.stateRolePermissions, event.getPostState(), role,
+          addPermissions(config.stateRolePermissions, event.getPostState(), role,
               grants.get(role));
         }
       }
@@ -64,21 +64,21 @@ class AuthorisationCaseStateGenerator<T, S, R extends HasRole> implements Config
           HasAccessControl accessHolder = objenesis.newInstance(klass);
           SetMultimap<HasRole, Permission> roleGrants = accessHolder.getGrants();
           for (HasRole key : roleGrants.keys()) {
-            addPermissions(config.builder.stateRolePermissions, Set.of(state), (R)key, roleGrants.get(key));
+            addPermissions(config.stateRolePermissions, Set.of(state), (R)key, roleGrants.get(key));
           }
         }
       }
     }
 
     List<Map<String, Object>> result = Lists.newArrayList();
-    for (Cell<S, R, Set<Permission>> stateRolePermission : config.builder.stateRolePermissions.cellSet()) {
+    for (Cell<S, R, Set<Permission>> stateRolePermission : config.stateRolePermissions.cellSet()) {
       if (stateRolePermission.getColumnKey().toString().matches("\\[.*?\\]")) {
         // Ignore CCD roles.
         continue;
       }
       Map<String, Object> permission = Maps.newHashMap();
       result.add(permission);
-      permission.put("CaseTypeID", config.builder.caseType);
+      permission.put("CaseTypeID", config.caseType);
       permission.put("LiveFrom", "01/01/2017");
       permission.put("CaseStateID", stateRolePermission.getRowKey());
       permission.put("UserRole", stateRolePermission.getColumnKey().getRole());

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
@@ -55,9 +55,9 @@ class AuthorisationCaseStateGenerator<T, S, R extends HasRole> implements Config
     }
 
     Objenesis objenesis = new ObjenesisStd();
-    for (S state : config.stateArg.getEnumConstants()) {
+    for (S state : config.stateClass.getEnumConstants()) {
       String enumFieldName = ((Enum)state).name();
-      CCD ccd = config.stateArg.getField(enumFieldName).getAnnotation(CCD.class);
+      CCD ccd = config.stateClass.getField(enumFieldName).getAnnotation(CCD.class);
 
       if (null != ccd) {
         for (var klass : ccd.access()) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
@@ -30,7 +30,7 @@ class AuthorisationCaseStateGenerator<T, S, R extends HasRole> implements Config
   @SneakyThrows
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
 
-    for (Event<T, R, S> event : config.events) {
+    for (Event<T, R, S> event : config.events.values()) {
       if (event.getPreState().equals(config.allStates)) {
         continue;
       }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGenerator.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.ccd.sdk.api.HasRole;
 class AuthorisationCaseTypeGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
 
-    Class<?> roleEnum = config.roleClass;
+    Class<?> roleEnum = config.getRoleClass();
     List<Map<String, Object>> result = Lists.newArrayList();
     if (roleEnum.isEnum()) {
       for (Object enumConstant : roleEnum.getEnumConstants()) {
@@ -24,7 +24,7 @@ class AuthorisationCaseTypeGenerator<T, S, R extends HasRole> implements ConfigG
           if (!r.getRole().matches("\\[.+\\]")) {
             result.add(Map.of(
                 "LiveFrom", "01/01/2017",
-                "CaseTypeID", config.caseType,
+                "CaseTypeID", config.getCaseType(),
                 "UserRole", r.getRole(),
                 "CRUD", r.getCaseTypePermissions()
             ));

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGenerator.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.ccd.sdk.api.HasRole;
 class AuthorisationCaseTypeGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
 
-    Class<?> roleEnum = config.roleType;
+    Class<?> roleEnum = config.roleClass;
     List<Map<String, Object>> result = Lists.newArrayList();
     if (roleEnum.isEnum()) {
       for (Object enumConstant : roleEnum.getEnumConstants()) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -24,7 +24,7 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
 
     File folder = new File(root.getPath(), "CaseEvent");
     folder.mkdir();
-    for (Event event : config.events) {
+    for (Event event : config.events.values()) {
       Path output = Paths.get(folder.getPath(), event.getId() + ".json");
 
       JsonUtils.mergeInto(output, serialise(config.caseType, event, config.allStates,

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -27,7 +27,7 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     for (Event event : config.events) {
       Path output = Paths.get(folder.getPath(), event.getId() + ".json");
 
-      JsonUtils.mergeInto(output, serialise(config.builder.caseType, event, config.allStates,
+      JsonUtils.mergeInto(output, serialise(config.caseType, event, config.allStates,
           config.builder.callbackHost),
           new AddMissing(), "ID");
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -24,11 +24,11 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
 
     File folder = new File(root.getPath(), "CaseEvent");
     folder.mkdir();
-    for (Event event : config.events.values()) {
+    for (Event event : config.getEvents().values()) {
       Path output = Paths.get(folder.getPath(), event.getId() + ".json");
 
-      JsonUtils.mergeInto(output, serialise(config.caseType, event, config.allStates,
-          config.callbackHost),
+      JsonUtils.mergeInto(output, serialise(config.getCaseType(), event, config.getAllStates(),
+          config.getCallbackHost()),
           new AddMissing(), "ID");
     }
   }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -28,7 +28,7 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
       Path output = Paths.get(folder.getPath(), event.getId() + ".json");
 
       JsonUtils.mergeInto(output, serialise(config.caseType, event, config.allStates,
-          config.builder.callbackHost),
+          config.callbackHost),
           new AddMissing(), "ID");
     }
   }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToComplexTypesGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToComplexTypesGenerator.java
@@ -25,8 +25,8 @@ class CaseEventToComplexTypesGenerator<T, S, R extends HasRole> implements
     ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    for (Event event : config.events) {
-      FieldCollection collection = event.getFields().build();
+    for (Event event : config.events.values()) {
+      FieldCollection collection = event.getFields();
       List<Map<String, Object>> entries = Lists.newArrayList();
       List<FieldCollection.FieldCollectionBuilder> complexFields = collection.getComplexFields();
       expand(complexFields, entries, event.getId(), null, "");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToComplexTypesGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToComplexTypesGenerator.java
@@ -25,7 +25,7 @@ class CaseEventToComplexTypesGenerator<T, S, R extends HasRole> implements
     ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    for (Event event : config.events.values()) {
+    for (Event event : config.getEvents().values()) {
       FieldCollection collection = event.getFields();
       List<Map<String, Object>> entries = Lists.newArrayList();
       List<FieldCollection.FieldCollectionBuilder> complexFields = collection.getComplexFields();

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
@@ -62,7 +62,7 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
           }
 
           if (midEventCallbacks.contains(event.getId(), pageId.toString())) {
-            info.put("CallBackURLMidEvent", config.builder.callbackHost + "/callbacks/mid-event?page="
+            info.put("CallBackURLMidEvent", config.callbackHost + "/callbacks/mid-event?page="
                 + URLEncoder.encode(pageId.toString(), StandardCharsets.UTF_8));
             midEventCallbacks.remove(event.getId(), pageId.toString());
           }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
@@ -24,7 +24,7 @@ import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    for (Event<T, R, S> event : config.events.values()) {
+    for (Event<T, R, S> event : config.getEvents().values()) {
       // For use in tracking which callbacks have been written.
       Multimap<String, String> writtenCallbacks = HashMultimap.create();
       FieldCollection collection = event.getFields();
@@ -36,7 +36,7 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
           entries.add(info);
           info.put("LiveFrom", "01/01/2017");
           info.put("CaseEventID", event.getId());
-          info.put("CaseTypeID", config.caseType);
+          info.put("CaseTypeID", config.getCaseType());
           Field field = fb.build();
           info.put("CaseFieldID", field.getId());
           String context =
@@ -62,7 +62,7 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
           // Include any mid-event callbacks only on the first page's entry
           if (collection.getPagesToMidEvent().containsKey(pageId.toString())
               && !writtenCallbacks.containsEntry(event.getId(), pageId.toString())) {
-            info.put("CallBackURLMidEvent", config.callbackHost + "/callbacks/mid-event?page="
+            info.put("CallBackURLMidEvent", config.getCallbackHost() + "/callbacks/mid-event?page="
                 + URLEncoder.encode(pageId.toString(), StandardCharsets.UTF_8));
             writtenCallbacks.put(event.getId(), pageId.toString());
           }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.ccd.sdk.generator;
 
-import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Table;
+import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
 import java.io.File;
 import java.net.URLEncoder;
@@ -18,18 +18,16 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.Field;
 import uk.gov.hmcts.ccd.sdk.api.FieldCollection;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
-import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
 import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 
 @Component
 class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    // Make a copy for use in tracking which callbacks have been written.
-    Table<String, String, MidEvent<T, S>> midEventCallbacks =
-        HashBasedTable.create(config.midEventCallbacks);
-    for (Event<T, R, S> event : config.events) {
-      FieldCollection collection = event.getFields().build();
+    for (Event<T, R, S> event : config.events.values()) {
+      // For use in tracking which callbacks have been written.
+      Multimap<String, String> writtenCallbacks = HashMultimap.create();
+      FieldCollection collection = event.getFields();
       if (collection.getFields().size() > 0) {
         List<Map<String, Object>> entries = Lists.newArrayList();
         List<Field.FieldBuilder> fields = collection.getFields();
@@ -61,10 +59,12 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
             info.put("FieldShowCondition", field.getShowCondition());
           }
 
-          if (midEventCallbacks.contains(event.getId(), pageId.toString())) {
+          // Include any mid-event callbacks only on the first page's entry
+          if (collection.getPagesToMidEvent().containsKey(pageId.toString())
+              && !writtenCallbacks.containsEntry(event.getId(), pageId.toString())) {
             info.put("CallBackURLMidEvent", config.callbackHost + "/callbacks/mid-event?page="
                 + URLEncoder.encode(pageId.toString(), StandardCharsets.UTF_8));
-            midEventCallbacks.remove(event.getId(), pageId.toString());
+            writtenCallbacks.put(event.getId(), pageId.toString());
           }
 
           if (collection.getPageShowConditions().containsKey(field.getPage())) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -202,11 +202,6 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
       }
     }
 
-    List<uk.gov.hmcts.ccd.sdk.api.Field> fs = config.explicitFields;
-    for (uk.gov.hmcts.ccd.sdk.api.Field field : fs) {
-      explicitFields.put(field.getId(), field);
-    }
-
     List<Map<String, Object>> result = Lists.newArrayList();
     for (String fieldId : explicitFields.keySet()) {
       uk.gov.hmcts.ccd.sdk.api.Field field = explicitFields.get(fieldId);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -27,7 +27,6 @@ import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 import uk.gov.hmcts.ccd.sdk.api.Event;
-import uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Label;
 import uk.gov.hmcts.ccd.sdk.type.FieldType;
@@ -203,9 +202,8 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
       }
     }
 
-    List<uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder> fs = config.builder.explicitFields;
-    for (FieldBuilder explicitField : fs) {
-      uk.gov.hmcts.ccd.sdk.api.Field field = explicitField.build();
+    List<uk.gov.hmcts.ccd.sdk.api.Field> fs = config.explicitFields;
+    for (uk.gov.hmcts.ccd.sdk.api.Field field : fs) {
       explicitFields.put(field.getId(), field);
     }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -41,9 +41,9 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
   @Override
   public void write(
       File outputFolder, ResolvedCCDConfig<T, S, R> config) {
-    List<Map<String, Object>> fields = toComplex(config.caseClass, config.caseType);
+    List<Map<String, Object>> fields = toComplex(config.getCaseClass(), config.getCaseType());
 
-    Map<String, Object> history = getField(config.caseType, "caseHistory");
+    Map<String, Object> history = getField(config.getCaseType(), "caseHistory");
     history.put("Label", " ");
     history.put("FieldType", "CaseHistoryViewer");
     fields.add(history);
@@ -192,7 +192,7 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
   private static <T, S, R extends HasRole> List<Map<String, Object>> getExplicitFields(
       ResolvedCCDConfig<T, S, R> config) {
     Map<String, uk.gov.hmcts.ccd.sdk.api.Field> explicitFields = Maps.newHashMap();
-    for (Event event : config.events.values()) {
+    for (Event event : config.getEvents().values()) {
       List<uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder> fc = event.getFields()
           .getExplicitFields();
 
@@ -205,8 +205,8 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     List<Map<String, Object>> result = Lists.newArrayList();
     for (String fieldId : explicitFields.keySet()) {
       uk.gov.hmcts.ccd.sdk.api.Field field = explicitFields.get(fieldId);
-      Map<String, Object> fieldData = getField(config.caseType, fieldId);
-      Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.caseClass, fieldId);
+      Map<String, Object> fieldData = getField(config.getCaseType(), fieldId);
+      Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.getCaseClass(), fieldId);
       // Don't export inbuilt metadata fields. Ignore unwrapped complex types
       if (fieldId.matches("\\[.+\\]") || unwrapped.isPresent()) {
         continue;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -192,8 +192,8 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
   private static <T, S, R extends HasRole> List<Map<String, Object>> getExplicitFields(
       ResolvedCCDConfig<T, S, R> config) {
     Map<String, uk.gov.hmcts.ccd.sdk.api.Field> explicitFields = Maps.newHashMap();
-    for (Event event : config.events) {
-      List<uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder> fc = event.getFields().build()
+    for (Event event : config.events.values()) {
+      List<uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder> fc = event.getFields()
           .getExplicitFields();
 
       for (uk.gov.hmcts.ccd.sdk.api.Field.FieldBuilder fieldBuilder : fc) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -42,9 +42,9 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
   @Override
   public void write(
       File outputFolder, ResolvedCCDConfig<T, S, R> config) {
-    List<Map<String, Object>> fields = toComplex(config.typeArg, config.builder.caseType);
+    List<Map<String, Object>> fields = toComplex(config.typeArg, config.caseType);
 
-    Map<String, Object> history = getField(config.builder.caseType, "caseHistory");
+    Map<String, Object> history = getField(config.caseType, "caseHistory");
     history.put("Label", " ");
     history.put("FieldType", "CaseHistoryViewer");
     fields.add(history);
@@ -212,7 +212,7 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     List<Map<String, Object>> result = Lists.newArrayList();
     for (String fieldId : explicitFields.keySet()) {
       uk.gov.hmcts.ccd.sdk.api.Field field = explicitFields.get(fieldId);
-      Map<String, Object> fieldData = getField(config.builder.caseType, fieldId);
+      Map<String, Object> fieldData = getField(config.caseType, fieldId);
       Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.typeArg, fieldId);
       // Don't export inbuilt metadata fields. Ignore unwrapped complex types
       if (fieldId.matches("\\[.+\\]") || unwrapped.isPresent()) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -41,7 +41,7 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
   @Override
   public void write(
       File outputFolder, ResolvedCCDConfig<T, S, R> config) {
-    List<Map<String, Object>> fields = toComplex(config.typeArg, config.caseType);
+    List<Map<String, Object>> fields = toComplex(config.caseClass, config.caseType);
 
     Map<String, Object> history = getField(config.caseType, "caseHistory");
     history.put("Label", " ");
@@ -206,7 +206,7 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     for (String fieldId : explicitFields.keySet()) {
       uk.gov.hmcts.ccd.sdk.api.Field field = explicitFields.get(fieldId);
       Map<String, Object> fieldData = getField(config.caseType, fieldId);
-      Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.typeArg, fieldId);
+      Optional<JsonUnwrapped> unwrapped = isUnwrappedField(config.caseClass, fieldId);
       // Don't export inbuilt metadata fields. Ignore unwrapped complex types
       if (fieldId.matches("\\[.+\\]") || unwrapped.isPresent()) {
         continue;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseRoleGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseRoleGenerator.java
@@ -26,9 +26,9 @@ public class CaseRoleGenerator<T, S, R extends HasRole> implements ConfigGenerat
 
     final Path path = Paths.get(rootOutputfolder.getPath(), "CaseRoles.json");
 
-    final List<Map<String, Object>> caseRoles = Arrays.stream(config.roleClass.getEnumConstants())
+    final List<Map<String, Object>> caseRoles = Arrays.stream(config.getRoleClass().getEnumConstants())
         .filter(x -> ((HasRole)x).getRole().matches("^\\[.+\\]$"))
-        .map(o -> enumToJsonMap(config.caseType, config.roleClass, o, ((HasRole) o).getRole()))
+        .map(o -> enumToJsonMap(config.getCaseType(), config.getRoleClass(), o, ((HasRole) o).getRole()))
         .collect(toList());
 
     mergeInto(path, caseRoles, new AddMissing(), "ID");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseRoleGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseRoleGenerator.java
@@ -26,9 +26,9 @@ public class CaseRoleGenerator<T, S, R extends HasRole> implements ConfigGenerat
 
     final Path path = Paths.get(rootOutputfolder.getPath(), "CaseRoles.json");
 
-    final List<Map<String, Object>> caseRoles = Arrays.stream(config.roleType.getEnumConstants())
+    final List<Map<String, Object>> caseRoles = Arrays.stream(config.roleClass.getEnumConstants())
         .filter(x -> ((HasRole)x).getRole().matches("^\\[.+\\]$"))
-        .map(o -> enumToJsonMap(config.caseType, config.roleType, o, ((HasRole) o).getRole()))
+        .map(o -> enumToJsonMap(config.caseType, config.roleClass, o, ((HasRole) o).getRole()))
         .collect(toList());
 
     mergeInto(path, caseRoles, new AddMissing(), "ID");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
@@ -26,13 +26,13 @@ class CaseTypeTabGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
 
     List<Map<String, Object>> result = Lists.newArrayList();
-    result.add(buildField(config.caseType, "CaseHistory", "caseHistory", "History", 1, 1, ""));
+    result.add(buildField(config.getCaseType(), "CaseHistory", "caseHistory", "History", 1, 1, ""));
 
     List<Map<String, Object>> caseFields = Lists.newArrayList();
 
     int tabDisplayOrder = 2;
 
-    for (Tab<T, R> tab : config.tabs) {
+    for (Tab<T, R> tab : config.getTabs()) {
       List<String> roles = tab.getRorRolesAsString();
 
       // if no roles have been specified leave UserRole empty
@@ -41,7 +41,7 @@ class CaseTypeTabGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
       }
 
       for (String role : roles) {
-        addTab(config.caseType, result, caseFields, tabDisplayOrder++, tab, role);
+        addTab(config.getCaseType(), result, caseFields, tabDisplayOrder++, tab, role);
       }
     }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Tab;
-import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
 import uk.gov.hmcts.ccd.sdk.api.TabField;
 import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 
@@ -33,8 +32,7 @@ class CaseTypeTabGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
 
     int tabDisplayOrder = 2;
 
-    for (TabBuilder<T, R> tb : config.builder.tabs) {
-      Tab<T, R> tab = tb.build();
+    for (Tab<T, R> tab : config.tabs) {
       List<String> roles = tab.getRorRolesAsString();
 
       // if no roles have been specified leave UserRole empty

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGenerator.java
@@ -18,7 +18,7 @@ class ComplexTypeGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
     File complexTypes = new File(root, "ComplexTypes");
     complexTypes.mkdir();
-    Map<Class, Integer> types = config.types.entrySet().stream().filter(x -> !x.getKey().isEnum())
+    Map<Class, Integer> types = config.getTypes().entrySet().stream().filter(x -> !x.getKey().isEnum())
         .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
 
     if (types.isEmpty()) {
@@ -35,7 +35,7 @@ class ComplexTypeGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
         continue;
       }
 
-      List<Map<String, Object>> fields = CaseFieldGenerator.toComplex(c, config.caseType);
+      List<Map<String, Object>> fields = CaseFieldGenerator.toComplex(c, config.getCaseType());
 
       for (Map<String, Object> info : fields) {
         info.put("ListElementCode", info.get("ID"));

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/FixedListGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/FixedListGenerator.java
@@ -21,7 +21,7 @@ class FixedListGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     File dir = root.toPath().resolve("FixedLists").toFile();
     dir.mkdir();
 
-    for (Class c : config.types.keySet()) {
+    for (Class c : config.getTypes().keySet()) {
       ComplexType complexType = (ComplexType) c.getAnnotation(ComplexType.class);
       if (c.isEnum() && (complexType == null || complexType.generate())) {
         List<Map<String, Object>> fields = Lists.newArrayList();

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/JSONConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/JSONConfigGenerator.java
@@ -48,10 +48,10 @@ public class JSONConfigGenerator<T, S, R extends HasRole> {
     List<Map<String, Object>> fields = Lists.newArrayList();
     fields.add(Map.of(
         "LiveFrom", "01/01/2017",
-        "ID", builder.caseType,
-        "Name", builder.caseName,
-        "Description", builder.caseDesc,
-        "JurisdictionID", builder.jurId,
+        "ID", builder.getCaseType(),
+        "Name", builder.getCaseName(),
+        "Description", builder.getCaseDesc(),
+        "JurisdictionID", builder.getJurId(),
         "SecurityClassification", "Public"
     ));
     Path output = Paths.get(outputfolder.getPath(),"CaseType.json");
@@ -62,9 +62,9 @@ public class JSONConfigGenerator<T, S, R extends HasRole> {
     List<Map<String, Object>> fields = Lists.newArrayList();
     fields.add(ImmutableMap.of(
         "LiveFrom", "01/01/2017",
-        "ID", builder.jurId,
-        "Name", builder.jurName,
-        "Description", builder.jurDesc
+        "ID", builder.getJurId(),
+        "Name", builder.getJurName(),
+        "Description", builder.getJurDesc()
     ));
     Path output = Paths.get(outputfolder.getPath(),"Jurisdiction.json");
     JsonUtils.mergeInto(output, fields, new JsonUtils.AddMissing(), "ID");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/JSONConfigGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/JSONConfigGenerator.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 
@@ -33,8 +32,8 @@ public class JSONConfigGenerator<T, S, R extends HasRole> {
       writer.write(outputfolder, config);
     }
 
-    generateJurisdiction(outputfolder, config.builder);
-    generateCaseType(outputfolder, config.builder);
+    generateJurisdiction(outputfolder, config);
+    generateCaseType(outputfolder, config);
   }
 
   @SneakyThrows
@@ -45,7 +44,7 @@ public class JSONConfigGenerator<T, S, R extends HasRole> {
     outputfolder.mkdirs();
   }
 
-  private void generateCaseType(File outputfolder, ConfigBuilderImpl builder) {
+  private void generateCaseType(File outputfolder, ResolvedCCDConfig<T, S, R> builder) {
     List<Map<String, Object>> fields = Lists.newArrayList();
     fields.add(Map.of(
         "LiveFrom", "01/01/2017",
@@ -59,7 +58,7 @@ public class JSONConfigGenerator<T, S, R extends HasRole> {
     JsonUtils.mergeInto(output, fields, new JsonUtils.AddMissing(), "ID");
   }
 
-  private void generateJurisdiction(File outputfolder, ConfigBuilderImpl builder) {
+  private void generateJurisdiction(File outputfolder, ResolvedCCDConfig<T, S, R> builder) {
     List<Map<String, Object>> fields = Lists.newArrayList();
     fields.add(ImmutableMap.of(
         "LiveFrom", "01/01/2017",

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchCasesResultFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchCasesResultFieldsGenerator.java
@@ -19,13 +19,13 @@ class SearchCasesResultFieldsGenerator<T, S, R extends HasRole> implements
     ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    List<SearchCasesResultField> fields = config.searchCaseResultFields.stream()
+    List<SearchCasesResultField> fields = config.getSearchCaseResultFields().stream()
         .flatMap(x -> x.getFields().stream())
         .collect(Collectors.toList());
 
     List<Map<String, Object>> jsonFields = IntStream
         .range(0, fields.size())
-        .mapToObj(i -> buildField(config.caseType, fields.get(i), i + 1))
+        .mapToObj(i -> buildField(config.getCaseType(), fields.get(i), i + 1))
         .collect(Collectors.toList());
 
     if (!jsonFields.isEmpty()) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchCasesResultFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchCasesResultFieldsGenerator.java
@@ -19,8 +19,8 @@ class SearchCasesResultFieldsGenerator<T, S, R extends HasRole> implements
     ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    List<SearchCasesResultField> fields = config.builder.searchCaseResultFields.stream()
-        .flatMap(builder -> builder.build().getFields().stream())
+    List<SearchCasesResultField> fields = config.searchCaseResultFields.stream()
+        .flatMap(x -> x.getFields().stream())
         .collect(Collectors.toList());
 
     List<Map<String, Object>> jsonFields = IntStream

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchFieldAndResultGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchFieldAndResultGenerator.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Search;
-import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.SearchField;
 import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 
@@ -19,22 +18,20 @@ import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 class SearchFieldAndResultGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    generateFields(root, config.caseType, config.builder.searchInputFields, "SearchInputFields");
-    generateFields(root, config.caseType, config.builder.searchResultFields, "SearchResultFields");
+    generateFields(root, config.caseType, config.searchInputFields, "SearchInputFields");
+    generateFields(root, config.caseType, config.searchResultFields, "SearchResultFields");
   }
 
   private static void generateFields(
           File root,
           String caseType,
-          List<SearchBuilder> searchFields,
+          List<Search> searchFields,
           String fileName
   ) {
     List<Map<String, Object>> result = Lists.newArrayList();
 
     int displayOrder = 1;
-    for (SearchBuilder wb : searchFields) {
-      Search search = wb.build();
-
+    for (Search search : searchFields) {
       for (SearchField field : search.getFields()) {
         Map<String, Object> map = buildField(caseType, field.getId(), field.getLabel(),
                 displayOrder++);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchFieldAndResultGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchFieldAndResultGenerator.java
@@ -18,8 +18,8 @@ import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 class SearchFieldAndResultGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    generateFields(root, config.caseType, config.searchInputFields, "SearchInputFields");
-    generateFields(root, config.caseType, config.searchResultFields, "SearchResultFields");
+    generateFields(root, config.getCaseType(), config.getSearchInputFields(), "SearchInputFields");
+    generateFields(root, config.getCaseType(), config.getSearchResultFields(), "SearchResultFields");
   }
 
   private static void generateFields(

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/StateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/StateGenerator.java
@@ -21,9 +21,9 @@ class StateGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
     List<Map<String, Object>> result = Lists.newArrayList();
     int i = 1;
-    if (config.stateClass.isEnum()) {
-      for (Object enumConstant : config.stateClass.getEnumConstants()) {
-        Map<String, Object> field = enumToJsonMap(config.caseType, config.stateClass, enumConstant,
+    if (config.getStateClass().isEnum()) {
+      for (Object enumConstant : config.getStateClass().getEnumConstants()) {
+        Map<String, Object> field = enumToJsonMap(config.getCaseType(), config.getStateClass(), enumConstant,
             enumConstant.toString());
         field.put("DisplayOrder", i++);
         result.add(field);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/StateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/StateGenerator.java
@@ -21,9 +21,9 @@ class StateGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
     List<Map<String, Object>> result = Lists.newArrayList();
     int i = 1;
-    if (config.stateArg.isEnum()) {
-      for (Object enumConstant : config.stateArg.getEnumConstants()) {
-        Map<String, Object> field = enumToJsonMap(config.caseType, config.stateArg, enumConstant,
+    if (config.stateClass.isEnum()) {
+      for (Object enumConstant : config.stateClass.getEnumConstants()) {
+        Map<String, Object> field = enumToJsonMap(config.caseType, config.stateClass, enumConstant,
             enumConstant.toString());
         field.put("DisplayOrder", i++);
         result.add(field);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/WorkBasketGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/WorkBasketGenerator.java
@@ -20,8 +20,8 @@ import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 class WorkBasketGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    generateFields(root, config.caseType, config.workBasketInputFields, "WorkBasketInputFields");
-    generateFields(root, config.caseType, config.workBasketResultFields, "WorkBasketResultFields");
+    generateFields(root, config.getCaseType(), config.getWorkBasketInputFields(), "WorkBasketInputFields");
+    generateFields(root, config.getCaseType(), config.getWorkBasketResultFields(), "WorkBasketResultFields");
   }
 
   private static void generateFields(File root, String caseType,

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/WorkBasketGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/WorkBasketGenerator.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
-import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasketField;
 import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 
@@ -21,18 +20,16 @@ import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
 class WorkBasketGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
 
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
-    generateFields(root, config.caseType, config.builder.workBasketInputFields, "WorkBasketInputFields");
-    generateFields(root, config.caseType, config.builder.workBasketResultFields, "WorkBasketResultFields");
+    generateFields(root, config.caseType, config.workBasketInputFields, "WorkBasketInputFields");
+    generateFields(root, config.caseType, config.workBasketResultFields, "WorkBasketResultFields");
   }
 
   private static void generateFields(File root, String caseType,
-      List<WorkBasketBuilder> workBasketFields, String fileName) {
+      List<WorkBasket> workBasketFields, String fileName) {
     List<Map<String, Object>> result = Lists.newArrayList();
 
     int displayOrder = 1;
-    for (WorkBasketBuilder wb : workBasketFields) {
-      WorkBasket workBasket = wb.build();
-
+    for (WorkBasket workBasket : workBasketFields) {
       for (WorkBasketField field : workBasket.getFields()) {
         Map<String, Object> map = buildField(caseType, field.getId(), field.getLabel(),
             displayOrder++, field.getListElementCode(), field.getShowCondition());

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
@@ -42,7 +42,7 @@ public class CallbackController {
     this.mapper = mapper;
     for (ResolvedCCDConfig<?, ?, ?> config : configs) {
       this.caseTypeToJavaType.put(config.caseType,
-          mapper.getTypeFactory().constructParametricType(CaseDetails.class, config.typeArg, config.stateArg));
+          mapper.getTypeFactory().constructParametricType(CaseDetails.class, config.caseClass, config.stateClass));
     }
   }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
@@ -38,11 +38,12 @@ public class CallbackController {
 
   @Autowired
   public CallbackController(Collection<ResolvedCCDConfig<?, ?, ?>> configs, ObjectMapper mapper) {
-    this.caseTypeToConfig = Maps.uniqueIndex(configs, x -> x.caseType);
+    this.caseTypeToConfig = Maps.uniqueIndex(configs, x -> x.getCaseType());
     this.mapper = mapper;
     for (ResolvedCCDConfig<?, ?, ?> config : configs) {
-      this.caseTypeToJavaType.put(config.caseType,
-          mapper.getTypeFactory().constructParametricType(CaseDetails.class, config.caseClass, config.stateClass));
+      this.caseTypeToJavaType.put(config.getCaseType(),
+          mapper.getTypeFactory().constructParametricType(CaseDetails.class, config.getCaseClass(),
+              config.getStateClass()));
     }
   }
 
@@ -104,7 +105,7 @@ public class CallbackController {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Case type not found: " + caseType);
     }
 
-    Event<?, ?, ?> result = caseTypeToConfig.get(caseType).events.get(request.getEventId());
+    Event<?, ?, ?> result = caseTypeToConfig.get(caseType).getEvents().get(request.getEventId());
     if (result == null) {
       log.warn("Unknown event " + request.getEventId());
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Case event not found: " + request.getEventId());

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
@@ -89,7 +89,12 @@ public class CallbackController {
   }
 
   <T> T findCallback(CallbackRequest request, TypedPropertyGetter<Event<?, ?, ?>, T> getter) {
-    return getter.get(findCaseEvent(request));
+    T result = getter.get(findCaseEvent(request));
+    if (result == null) {
+      log.warn("No callback for event " + request.getEventId());
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Callback not found: " + request.getEventId());
+    }
+    return result;
   }
 
   <T> Event<?, ?, ?> findCaseEvent(CallbackRequest request) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import de.cronn.reflection.util.TypedPropertyGetter;
 import java.util.Collection;
 import java.util.Map;
 import lombok.SneakyThrows;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
@@ -48,7 +50,7 @@ public class CallbackController {
   @PostMapping("/about-to-start")
   public AboutToStartOrSubmitResponse aboutToStart(@RequestBody CallbackRequest request) {
     log.info("About to start event ID: " + request.getEventId());
-    return findCallback(findCaseType(request).aboutToStartCallbacks, request.getEventId())
+    return findCallback(request, Event::getAboutToStartCallback)
         .handle(convertCaseDetails(request.getCaseDetails()));
   }
 
@@ -56,7 +58,7 @@ public class CallbackController {
   @PostMapping("/about-to-submit")
   public AboutToStartOrSubmitResponse aboutToSubmit(@RequestBody CallbackRequest request) {
     log.info("About to submit event ID: " + request.getEventId());
-    return findCallback(findCaseType(request).aboutToSubmitCallbacks, request.getEventId())
+    return findCallback(request, Event::getAboutToSubmitCallback)
         .handle(convertCaseDetails(request.getCaseDetails()),
             convertCaseDetails(request.getCaseDetailsBefore(), request.getCaseDetails().getCaseTypeId()));
   }
@@ -65,7 +67,7 @@ public class CallbackController {
   @PostMapping("/submitted")
   public SubmittedCallbackResponse submitted(@RequestBody CallbackRequest request) {
     log.info("Submitted event ID: " + request.getEventId());
-    return findCallback(findCaseType(request).submittedCallbacks, request.getEventId())
+    return findCallback(request, Event::getSubmittedCallback)
         .handle(convertCaseDetails(request.getCaseDetails()), convertCaseDetails(request.getCaseDetailsBefore(),
             request.getCaseDetails().getCaseTypeId()));
   }
@@ -75,32 +77,35 @@ public class CallbackController {
   public AboutToStartOrSubmitResponse midEvent(@RequestBody CallbackRequest request,
                                             @RequestParam(name = "page") String page) {
     log.info("Mid event callback: {} for page {} ", request.getEventId(), page);
-    MidEvent m = findCaseType(request).midEventCallbacks.get(request.getEventId(), page);
-    if (null == m) {
+    MidEvent<?, ?> callback = findCaseEvent(request).getFields().getPagesToMidEvent().get(page);
+
+    if (null == callback) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Handler not found for "
           + request.getEventId() + " for page " + page);
     }
-    return m.handle(convertCaseDetails(request.getCaseDetails()),
+    return callback.handle(convertCaseDetails(request.getCaseDetails()),
         convertCaseDetails(request.getCaseDetailsBefore(),
             request.getCaseDetails().getCaseTypeId()));
   }
 
-  ResolvedCCDConfig<?, ?, ?> findCaseType(CallbackRequest request) {
+  <T> T findCallback(CallbackRequest request, TypedPropertyGetter<Event<?, ?, ?>, T> getter) {
+    return getter.get(findCaseEvent(request));
+  }
+
+  <T> Event<?, ?, ?> findCaseEvent(CallbackRequest request) {
     String caseType = request.getCaseDetails().getCaseTypeId();
     if (!caseTypeToConfig.containsKey(caseType)) {
       log.warn("No configuration found for case type " + caseType);
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Case type not found: " + caseType);
     }
 
-    return this.caseTypeToConfig.get(caseType);
-  }
-
-  <T> T findCallback(Map<String, T> callbacks, String eventId) {
-    if (!callbacks.containsKey(eventId)) {
-      log.warn("Handler not found for " + eventId);
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Handler not found for " + eventId);
+    Event<?, ?, ?> result = caseTypeToConfig.get(caseType).events.get(request.getEventId());
+    if (result == null) {
+      log.warn("Unknown event " + request.getEventId());
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Case event not found: " + request.getEventId());
     }
-    return callbacks.get(eventId);
+
+    return result;
   }
 
   CaseDetails convertCaseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails ccdDetails) {
@@ -119,4 +124,5 @@ public class CallbackController {
     }
     return mapper.readValue(json, caseTypeToJavaType.get(caseType));
   }
+
 }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/CallbackControllerTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/CallbackControllerTest.java
@@ -57,9 +57,16 @@ public class CallbackControllerTest {
 
   @SneakyThrows
   @Test
-  public void testNoCallbackReturns404() {
+  public void testUnknownEventReturns404() {
     this.makeRequest("submitted", "does-not-exist")
-        .andExpect(status().is4xxClientError());
+        .andExpect(status().is(404));
+  }
+
+  @SneakyThrows
+  @Test
+  public void testMissingCallbackReturns404() {
+    this.makeRequest("submitted", "addNotes")
+        .andExpect(status().is(404));
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Change description ###

Moves fields from ConfigBuilderImpl onto ResolvedCCDConfiguration and makes ConfigBuilderImpl package private.

Removed top level webhooks from ResolvedCCDConfiguration since they are already duplicated in the events.
