### PR TITLE
Set event display order to alphabetical by name

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.ccd.sdk.api.SearchCases.SearchCasesBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 
-class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, R> {
+public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, R> {
 
   private final ResolvedCCDConfig<T, S, R> config;
 
@@ -122,7 +122,7 @@ class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder<T, S, 
   @Override
   public TabBuilder<T, R> tab(String tabId, String tabLabel) {
     TabBuilder<T, R> result = (TabBuilder<T, R>) TabBuilder.builder(config.caseClass,
-        new PropertyUtils()).tabID(tabId).label(tabLabel);
+        new PropertyUtils()).tabID(tabId).labelText(tabLabel);
     tabs.add(result);
     return result;
   }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Tab.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Tab.java
@@ -16,7 +16,7 @@ import lombok.Data;
 @Data
 public class Tab<T, R extends HasRole> {
   private String tabID;
-  private String label;
+  private String labelText;
   private String showCondition;
   private int displayOrder;
   private List<TabField> fields;
@@ -65,7 +65,7 @@ public class Tab<T, R extends HasRole> {
       return this;
     }
 
-    public TabBuilder<T, R> field(String fieldName, String showCondition, String label) {
+    public TabBuilder<T, R> label(String fieldName, String showCondition, String label) {
       fields.add(TabField.builder().id(fieldName).showCondition(showCondition).label(label).build());
       return this;
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.ccd.sdk.generator;
 
+import static uk.gov.hmcts.ccd.sdk.generator.GeneratorUtils.sortDisplayOrderByEventName;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.io.File;
@@ -24,7 +26,10 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
 
     File folder = new File(root.getPath(), "CaseEvent");
     folder.mkdir();
-    for (Event event : config.getEvents().values()) {
+
+    List<Event<T, R, S>> events = sortDisplayOrderByEventName(config.getEvents().values());
+
+    for (Event event : events) {
       Path output = Paths.get(folder.getPath(), event.getId() + ".json");
 
       JsonUtils.mergeInto(output, serialise(config.getCaseType(), event, config.getAllStates(),
@@ -35,17 +40,12 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
 
   private List<Map<String, Object>> serialise(String caseTypeId, Event<T, R, S> event,
                                               Set<S> allStates, String callbackHost) {
-    int t = 1;
     List result = Lists.newArrayList();
     Map<String, Object> data = JsonUtils.getField(event.getId());
     result.add(data);
     data.put("Name", event.getName());
     data.put("Description", event.getDescription());
-    if (event.getDisplayOrder() != -1) {
-      data.put("DisplayOrder", event.getDisplayOrder());
-    } else {
-      data.put("DisplayOrder", t++);
-    }
+    data.put("DisplayOrder", event.getDisplayOrder());
     data.put("CaseTypeID", caseTypeId);
     if (event.isShowSummary()) {
       data.put("ShowSummary", "Y");

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
@@ -62,7 +62,7 @@ class CaseTypeTabGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
     int tabFieldDisplayOrder = 1;
     for (TabField tabField : tab.getFields()) {
       Map<String, Object> field = buildField(caseType, tab.getTabID() + role, tabField.getId(),
-          tab.getLabel(), tabDisplayOrder, tabFieldDisplayOrder, role);
+          tab.getLabelText(), tabDisplayOrder, tabFieldDisplayOrder, role);
       if (tab.getShowCondition() != null && tabFieldDisplayOrder == 1) {
         field.put("TabShowCondition", tab.getShowCondition());
       }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtils.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtils.java
@@ -26,4 +26,8 @@ public final class GeneratorUtils {
       })
       .collect(toList());
   }
+
+  public static <T, R extends HasRole, S> boolean hasAnyDisplayOrder(final Collection<Event<T, R, S>> events) {
+    return events.stream().anyMatch(event -> event.getDisplayOrder() != -1);
+  }
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtils.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtils.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.ccd.sdk.generator;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.HasRole;
+
+public final class GeneratorUtils {
+
+  private GeneratorUtils() {
+  }
+
+  public static <T, R extends HasRole, S> List<Event<T, R, S>> sortDisplayOrderByEventName(
+      final Collection<Event<T, R, S>> events) {
+
+    final AtomicInteger displayOrder = new AtomicInteger();
+
+    return events.stream()
+      .sorted((event1, event2) -> event1.getName().compareToIgnoreCase(event2.getName()))
+      .map(event -> {
+        event.setDisplayOrder(displayOrder.incrementAndGet());
+        return event;
+      })
+      .collect(toList());
+  }
+}

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtilsTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtilsTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.ccd.sdk.generator;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+import static uk.gov.hmcts.ccd.sdk.generator.GeneratorUtils.hasAnyDisplayOrder;
+import static uk.gov.hmcts.ccd.sdk.generator.GeneratorUtils.sortDisplayOrderByEventName;
 
 import java.util.List;
 import org.junit.Test;
@@ -21,7 +23,7 @@ public class GeneratorUtilsTest {
 
     List<Event<Object, HasRole, Object>> events = asList(event1, event2, event3, event4);
 
-    List<Event<Object, HasRole, Object>> results = GeneratorUtils.sortDisplayOrderByEventName(events);
+    List<Event<Object, HasRole, Object>> results = sortDisplayOrderByEventName(events);
 
     assertThat(results)
       .hasSize(4)
@@ -32,5 +34,31 @@ public class GeneratorUtilsTest {
         tuple(3, "h"),
         tuple(4, "t")
       );
+  }
+
+  @Test
+  public void shouldReturnTrueIfAnyDisplayOrderIsSet() {
+
+    Event<Object, HasRole, Object> event1 = Event.builder().build();
+    Event<Object, HasRole, Object> event2 = Event.builder().build();
+    Event<Object, HasRole, Object> event3 = Event.builder().displayOrder(1).build();
+    Event<Object, HasRole, Object> event4 = Event.builder().build();
+
+    List<Event<Object, HasRole, Object>> events = asList(event1, event2, event3, event4);
+
+    assertThat(hasAnyDisplayOrder(events)).isTrue();
+  }
+
+  @Test
+  public void shouldReturnFalseIfDisplayOrderIsNotSet() {
+
+    Event<Object, HasRole, Object> event1 = Event.builder().build();
+    Event<Object, HasRole, Object> event2 = Event.builder().build();
+    Event<Object, HasRole, Object> event3 = Event.builder().build();
+    Event<Object, HasRole, Object> event4 = Event.builder().build();
+
+    List<Event<Object, HasRole, Object>> events = asList(event1, event2, event3, event4);
+
+    assertThat(hasAnyDisplayOrder(events)).isFalse();
   }
 }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtilsTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/GeneratorUtilsTest.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.ccd.sdk.generator;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import java.util.List;
+import org.junit.Test;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.HasRole;
+
+public class GeneratorUtilsTest {
+
+  @Test
+  public void shouldSetDisplayOrderByAlphabeticalNameOrder() {
+
+    Event<Object, HasRole, Object> event1 = Event.builder().name("Az").build();
+    Event<Object, HasRole, Object> event2 = Event.builder().name("t").build();
+    Event<Object, HasRole, Object> event3 = Event.builder().name("ab").build();
+    Event<Object, HasRole, Object> event4 = Event.builder().name("h").build();
+
+    List<Event<Object, HasRole, Object>> events = asList(event1, event2, event3, event4);
+
+    List<Event<Object, HasRole, Object>> results = GeneratorUtils.sortDisplayOrderByEventName(events);
+
+    assertThat(results)
+      .hasSize(4)
+      .extracting(Event::getDisplayOrder, Event::getName)
+      .containsExactly(
+        tuple(1, "ab"),
+        tuple(2, "Az"),
+        tuple(3, "h"),
+        tuple(4, "t")
+      );
+  }
+}


### PR DESCRIPTION
### Change description ###
If there is no display order set then use alphabetical name ordering for display order of events
Make ConfigBuilderImpl class public, so that current tests do not break in NFD
Rename Tab api class method to label(String fieldName, String showCondition, String label) as it creates a field of label type


