### PR TITLE
Default ShowEventNotes as No, to remove event summary and description

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -28,7 +28,6 @@ public class Event<T, R extends HasRole, S> {
   private boolean explicitGrants;
   private boolean showSummary;
   private boolean showEventNotes;
-  private boolean showSummaryChangeOption;
   private AboutToStart<T, S> aboutToStartCallback;
   private AboutToSubmit<T, S> aboutToSubmitCallback;
   private Submitted<T, S> submittedCallback;
@@ -95,16 +94,6 @@ public class Event<T, R extends HasRole, S> {
       if (description == null) {
         description = n;
       }
-      return this;
-    }
-
-    public EventBuilder<T, R, S> showSummaryChangeOption(boolean b) {
-      this.showSummaryChangeOption = b;
-      return this;
-    }
-
-    public EventBuilder<T, R, S> showSummaryChangeOption() {
-      this.showSummaryChangeOption = true;
       return this;
     }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -64,13 +64,14 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     data.put("CaseTypeID", caseTypeId);
     if (event.isShowSummary()) {
       data.put("ShowSummary", "Y");
+    } else {
+      data.put("ShowSummary", "N");
     }
 
     if (event.isShowEventNotes()) {
       data.put("ShowEventNotes", "Y");
-    }
-    if (event.isShowSummaryChangeOption()) {
-      data.put("ShowSummaryChangeOption", "Y");
+    } else {
+      data.put("ShowEventNotes", "N");
     }
 
     if (!Strings.isNullOrEmpty(event.getEndButtonLabel())) {


### PR DESCRIPTION
### Change description ###
https://tools.hmcts.net/jira/browse/NFDIV-1097

Set ShowEventNotes to default to "N", to remove event summary and description entries on summary page.
Remove showSummaryChangeOption as CCD fails to load config if set.


