### PR TITLE
Add pre event hook to allow pre-processing of requests

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -165,6 +165,12 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
     config.callbackHost = s;
   }
 
+  @Override
+  public void addPreEventHook(
+      Function<Map<String, Object>, Map<String, Object>> hook) {
+    config.preEventHooks.add(hook);
+  }
+
   private WorkBasketBuilder getWorkBasketBuilder(List<WorkBasketBuilder> workBasketInputFields) {
     WorkBasketBuilder result = WorkBasketBuilder.builder(config.caseClass, new PropertyUtils());
     workBasketInputFields.add(result);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -4,9 +4,11 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.Event;
@@ -40,6 +42,7 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
   // Events by id
   ImmutableMap<String, Event<T, R, S>> events;
+  List<Function<Map<String, Object>, Map<String, Object>>> preEventHooks = new ArrayList<>();
   List<Tab<T, R>> tabs;
   List<WorkBasket> workBasketResultFields;
   List<WorkBasket> workBasketInputFields;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.ccd.sdk.api;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.SearchCases.SearchCasesBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
@@ -39,4 +41,6 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
   SearchCasesBuilder<T> searchCasesFields();
 
   void setCallbackHost(String s);
+
+  void addPreEventHook(Function<Map<String, Object>, Map<String, Object>> hook);
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CallbackController.java
@@ -133,12 +133,16 @@ public class CallbackController {
     }
 
     if (null != ccdDetails) {
-      Map<String, Object> migratedData = caseTypeToConfig.get(caseType).getPreEventHooks()
-          .stream()
-          .reduce(identity(), Function::andThen)
-          .apply(ccdDetails.getData());
+      try {
+        Map<String, Object> migratedData = caseTypeToConfig.get(caseType).getPreEventHooks()
+            .stream()
+            .reduce(identity(), Function::andThen)
+            .apply(ccdDetails.getData());
 
-      ccdDetails.setData(migratedData);
+        ccdDetails.setData(migratedData);
+      } catch (Exception e) {
+        log.error("Error running pre-event hooks", e);
+      }
     }
 
     String json = mapper.writeValueAsString(ccdDetails);

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/CallbackControllerTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/CallbackControllerTest.java
@@ -26,6 +26,8 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.BulkCaseConfig;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 
+import java.util.Map;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -43,9 +45,12 @@ public class CallbackControllerTest {
 
   @SneakyThrows
   @Test
-  public void testAboutToSubmit() {
-    this.makeRequest("about-to-submit", "addFamilyManCaseNumber")
-        .andExpect(status().isOk());
+  public void testAboutToSubmitWithMigration() {
+    Map<String, Object> data = Maps.newHashMap();
+    data.put("orderAppliesToAllChildren", "test");
+
+    this.makeRequest("about-to-submit", "CARE_SUPERVISION_EPO", "addFamilyManCaseNumber", data)
+      .andExpect(status().isOk());
   }
 
   @SneakyThrows
@@ -105,9 +110,14 @@ public class CallbackControllerTest {
 
   @SneakyThrows
   ResultActions makeRequest(String callback, String caseType, String eventId) {
+    return makeRequest(callback, caseType, eventId, Maps.newHashMap());
+  }
+
+  @SneakyThrows
+  ResultActions makeRequest(String callback, String caseType, String eventId, Map<String, Object> data) {
     return this.mockMvc.perform(post("/callbacks/" + callback)
         .contentType(MediaType.APPLICATION_JSON)
-        .content(new ObjectMapper().writeValueAsString(buildRequest(caseType, eventId))));
+        .content(new ObjectMapper().writeValueAsString(buildRequest(caseType, eventId, data))));
   }
 
   @SneakyThrows
@@ -121,11 +131,11 @@ public class CallbackControllerTest {
     return mapper.readValue(json, c);
   }
 
-  CallbackRequest buildRequest(String caseType, String eventId) {
+  CallbackRequest buildRequest(String caseType, String eventId, Map<String, Object> data) {
     return CallbackRequest.builder()
         .eventId(eventId)
         .caseDetails(CaseDetails.builder()
-            .data(Maps.newHashMap())
+            .data(data)
             .caseTypeId(caseType)
             .build())
         .build();

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -42,6 +42,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
 
   public void configure(ConfigBuilder<CaseData, State, UserRole> builder) {
     this.builder = builder;
+    builder.addPreEventHook(RetiredFields::migrate);
     builder.setCallbackHost("${CCD_DEF_CASE_SERVICE_BASE_URL}");
     builder.jurisdiction("PUBLICLAW", "Family Public Law", "Family Public Law desc");
     builder.omitHistoryForRoles(SYSTEM_UPDATE);

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/RetiredFields.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/RetiredFields.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.fpl;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+@Data
+@NoArgsConstructor
+public class RetiredFields {
+
+  private String orderAppliesToAllChildren;
+
+  @JsonIgnore
+  private static final Map<String, Consumer<Map<String, Object>>> migrations = Map.of(
+    "orderAppliesToAllChildren", data -> data.put("caseLocalAuthority", data.get("orderAppliesToAllChildren"))
+  );
+
+  public static Map<String, Object> migrate(Map<String, Object> data) {
+
+    for (String key : migrations.keySet()) {
+      if (data.containsKey(key) && null != data.get(key)) {
+        migrations.get(key).accept(data);
+        data.put(key, null);
+      }
+    }
+
+    return data;
+  }
+}

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/event/AddCaseNumber.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/event/AddCaseNumber.java
@@ -63,6 +63,13 @@ public class AddCaseNumber implements CCDConfig<CaseData, State, UserRole> {
       CaseData d = details.getData();
     d.setFamilyManCaseNumber("12345");
 
+    if (null != d.getRetiredFields().getOrderAppliesToAllChildren()) {
+      throw new RuntimeException("Retired field set");
+    }
+    if (null == d.getCaseLocalAuthority()) {
+      throw new RuntimeException("Migration did not run");
+    }
+
     return AboutToStartOrSubmitResponse.<CaseData, State>builder()
         .data(d)
         .build();

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.DynamicList;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
+import uk.gov.hmcts.reform.fpl.RetiredFields;
 import uk.gov.hmcts.reform.fpl.access.BulkScan;
 import uk.gov.hmcts.reform.fpl.access.SolicitorAccess;
 import uk.gov.hmcts.reform.fpl.enums.C2ApplicationType;
@@ -218,7 +219,6 @@ public class CaseData {
     private final Integer orderMonths;
     private final InterimEndDate interimEndDate;
     private final ChildSelector childSelector;
-    private final String orderAppliesToAllChildren;
     @PastOrPresent(message = "Date of issue cannot be in the future")
     private final LocalDate dateOfIssue;
     private final List<Element<GeneratedOrder>> orderCollection;
@@ -345,4 +345,8 @@ public class CaseData {
     private final String caseNote;
     private final List<Element<CaseNote>> caseNotes;
     private final OrganisationPolicy<UserRole> organisationPolicy;
+
+    @JsonUnwrapped()
+    private final RetiredFields retiredFields;
+
 }


### PR DESCRIPTION
### Change description ###

This change allows pre-event hooks to be added that can process the raw JSON before it's deserialized into the CaseData class. The example use case is to migrate data from old fields into new ones.

