### PR TITLE
Allow list display order

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
@@ -17,6 +17,8 @@ public @interface CCD {
 
   String regex() default "";
 
+  String listDisplayOrder() default "";
+
   FieldType typeOverride() default FieldType.Unspecified;
 
   String typeParameterOverride() default "";

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
@@ -17,7 +17,7 @@ public @interface CCD {
 
   String regex() default "";
 
-  String listDisplayOrder() default "";
+  String displayOrder() default "";
 
   FieldType typeOverride() default FieldType.Unspecified;
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
@@ -292,6 +292,10 @@ public class FieldCollection {
       if (null != cf) {
         f.label(cf.label());
         f.hint(cf.hint());
+
+        try {
+          f.fieldDisplayOrder(Integer.parseUnsignedInt(cf.listDisplayOrder()));
+        } catch (NumberFormatException ex) {}
       }
       return f;
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.capitalize;
 import static uk.gov.hmcts.ccd.sdk.FieldUtils.isUnwrappedField;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.google.common.base.Strings;
 import de.cronn.reflection.util.TypedPropertyGetter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -293,13 +294,19 @@ public class FieldCollection {
         f.label(cf.label());
         f.hint(cf.hint());
 
-        try {
-          f.fieldDisplayOrder(Integer.parseUnsignedInt(cf.listDisplayOrder()));
-        } catch (NumberFormatException ex) {
-          // If the optional listDisplayOrder is empty or an invalid number just do not set field value
+        if (!Strings.isNullOrEmpty(cf.displayOrder())) {
+          f.fieldDisplayOrder(updateFieldDisplayOrder(cf));
         }
       }
       return f;
+    }
+
+    private int updateFieldDisplayOrder(CCD cf) {
+      try {
+        return Integer.parseUnsignedInt(cf.displayOrder());
+      } catch (NumberFormatException ex) {
+        throw new RuntimeException("Invalid displayOrder value in CCD annotation for " + cf.name());
+      }
     }
 
     private <U> FieldBuilder<U, StateType, Type, Parent> createField(String id, Class<U> clazz) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
@@ -295,7 +295,9 @@ public class FieldCollection {
 
         try {
           f.fieldDisplayOrder(Integer.parseUnsignedInt(cf.listDisplayOrder()));
-        } catch (NumberFormatException ex) {}
+        } catch (NumberFormatException ex) {
+          // If the optional listDisplayOrder is empty or an invalid number just do not set field value
+        }
       }
       return f;
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -103,7 +103,7 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
           fieldInfo.put("FieldShowCondition", cf.showCondition());
         }
         if (!Strings.isNullOrEmpty(cf.displayOrder())) {
-          fieldInfo.put("ListDisplayOrder", cf.displayOrder());
+          fieldInfo.put("DisplayOrder", cf.displayOrder());
         }
       }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -102,6 +102,9 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
         if (!Strings.isNullOrEmpty(cf.showCondition())) {
           fieldInfo.put("FieldShowCondition", cf.showCondition());
         }
+        if (!Strings.isNullOrEmpty(cf.listDisplayOrder())) {
+          fieldInfo.put("ListDisplayOrder", cf.listDisplayOrder());
+        }
       }
 
       if (cf != null && cf.typeOverride() != FieldType.Unspecified) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -102,8 +102,8 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
         if (!Strings.isNullOrEmpty(cf.showCondition())) {
           fieldInfo.put("FieldShowCondition", cf.showCondition());
         }
-        if (!Strings.isNullOrEmpty(cf.listDisplayOrder())) {
-          fieldInfo.put("ListDisplayOrder", cf.listDisplayOrder());
+        if (!Strings.isNullOrEmpty(cf.displayOrder())) {
+          fieldInfo.put("ListDisplayOrder", cf.displayOrder());
         }
       }
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGenerator.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.ccd.sdk.generator;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,6 +56,22 @@ class ComplexTypeGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
         String prefix = maxDepth - depth + "_";
         path = Paths.get(complexTypes.getPath(), prefix + id + ".json");
       }
+
+      Collections.sort(fields, new Comparator<Map<String,Object>>() {
+        @Override
+        public int compare(Map<String,Object> o1, Map<String,Object> o2) {
+          String listOrder1 = (String)o1.get("ListDisplayOrder");
+          String listOrder2 = (String)o2.get("ListDisplayOrder");
+
+          if (listOrder1 == null) {
+            return listOrder2 == null ? 0 : 1;
+          } else if (listOrder2 == null) {
+            return -1;
+          }
+          return Integer.parseInt(listOrder1) - Integer.parseInt(listOrder2);
+        }
+      });
+
       JsonUtils.mergeInto(path, fields, new AddMissing(), "ListElementCode");
     }
   }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGenerator.java
@@ -57,23 +57,28 @@ class ComplexTypeGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
         path = Paths.get(complexTypes.getPath(), prefix + id + ".json");
       }
 
-      Collections.sort(fields, new Comparator<Map<String,Object>>() {
-        @Override
-        public int compare(Map<String,Object> o1, Map<String,Object> o2) {
-          String listOrder1 = (String)o1.get("ListDisplayOrder");
-          String listOrder2 = (String)o2.get("ListDisplayOrder");
-
-          if (listOrder1 == null) {
-            return listOrder2 == null ? 0 : 1;
-          } else if (listOrder2 == null) {
-            return -1;
-          }
-          return Integer.parseInt(listOrder1) - Integer.parseInt(listOrder2);
-        }
-      });
-
+      sortComplexTypesByDisplayOrder(fields);
       JsonUtils.mergeInto(path, fields, new AddMissing(), "ListElementCode");
     }
+  }
+
+  public void sortComplexTypesByDisplayOrder(List<Map<String, Object>> fields) {
+
+    Collections.sort(fields, new Comparator<Map<String,Object>>() {
+      @Override
+      public int compare(Map<String,Object> o1, Map<String,Object> o2) {
+        String listOrder1 = (String)o1.get("DisplayOrder");
+        String listOrder2 = (String)o2.get("DisplayOrder");
+
+        if (listOrder1 == null) {
+          return listOrder2 == null ? 0 : 1;
+        } else if (listOrder2 == null) {
+          return -1;
+        }
+        return Integer.parseInt(listOrder1) - Integer.parseInt(listOrder2);
+      }
+    });
+
   }
 
 }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGeneratorTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGeneratorTest.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import uk.gov.hmcts.ccd.sdk.generator.CaseFieldGenerator;
 
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGeneratorTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGeneratorTest.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.ccd.sdk.generator;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.reform.fpl.enums.State;
+import uk.gov.hmcts.reform.fpl.enums.UserRole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComplexTypeGeneratorTest {
+
+  public static class CCDDisplayOrderClass {
+    @CCD(displayOrder = "2")
+    private String stringField2;
+
+    @CCD(displayOrder = "6")
+    private String stringField6;
+
+    @CCD(displayOrder = "4")
+    private String stringField4;
+
+    @CCD(label = "No DisplayOrder")
+    private String displayOrder;
+
+    @CCD(displayOrder = "3")
+    private String stringField3;
+
+    @CCD(displayOrder = "5")
+    private String stringField5;
+
+    @CCD(displayOrder = "1")
+    private String stringField1;
+  }
+
+  public static class CCDInvalidClass {
+    @CCD(displayOrder = "a")
+    private String stringField1;
+  }
+
+  public static class CCDNoDisplayOrderClass {
+    @CCD(label = "Label2")
+    private String stringField1;
+
+    @CCD(label = "Label3")
+    private String stringField2;
+
+    @CCD(label = "Label1")
+    private String stringField3;
+  }
+
+  ComplexTypeGenerator<CCDDisplayOrderClass, State, UserRole> complexTypeGenerator;
+
+  @Test
+  public void shouldSortClassFieldsByDisplayOrder() {
+
+    List<Map<String, Object>> generatedFromCCDTestClass = CaseFieldGenerator
+      .toComplex(CCDDisplayOrderClass.class, "CCDDisplayOrderClass");
+
+    complexTypeGenerator = new ComplexTypeGenerator<>();
+    complexTypeGenerator.sortComplexTypesByDisplayOrder(generatedFromCCDTestClass);
+
+    for(Map<String, Object> fieldMap : generatedFromCCDTestClass){
+      System.out.println(fieldMap.get("DisplayOrder"));
+    }
+
+    assertThat(generatedFromCCDTestClass.get(0).get("DisplayOrder")).isEqualTo("1");
+    assertThat(generatedFromCCDTestClass.get(5).get("DisplayOrder")).isEqualTo("6");
+    assertThat(generatedFromCCDTestClass.get(6).get("DisplayOrder")).isNull();
+  }
+
+  @Test
+  public void sortShouldNotChangeFieldOrderIfNoDisplayOrderAttribute() {
+
+    List<Map<String, Object>> generatedFromCCDTestClass = CaseFieldGenerator
+      .toComplex(CCDNoDisplayOrderClass.class, "CCDNoDisplayOrderClass");
+
+    List<String> expected = new ArrayList<>();
+    for(Map<String, Object> fieldMap : generatedFromCCDTestClass){
+      expected.add((String) fieldMap.get("Label"));
+    }
+    complexTypeGenerator = new ComplexTypeGenerator<>();
+    complexTypeGenerator.sortComplexTypesByDisplayOrder(generatedFromCCDTestClass);
+
+    int counter = 0;
+    for(Map<String, Object> fieldMap : generatedFromCCDTestClass){
+      assertThat(generatedFromCCDTestClass.get(counter).get("Label")).isEqualTo(expected.get(counter));
+      counter++;
+    }
+  }
+
+  @Ignore
+  public void shouldPreventInvalidDisplayOrder() {
+    List<Map<String, Object>> generatedFromCCDTestClass = CaseFieldGenerator
+      .toComplex(CCDInvalidClass.class, "CCDInvalidClass");
+  }
+
+}

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGeneratorTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/ComplexTypeGeneratorTest.java
@@ -64,10 +64,6 @@ public class ComplexTypeGeneratorTest {
     complexTypeGenerator = new ComplexTypeGenerator<>();
     complexTypeGenerator.sortComplexTypesByDisplayOrder(generatedFromCCDTestClass);
 
-    for(Map<String, Object> fieldMap : generatedFromCCDTestClass){
-      System.out.println(fieldMap.get("DisplayOrder"));
-    }
-
     assertThat(generatedFromCCDTestClass.get(0).get("DisplayOrder")).isEqualTo("1");
     assertThat(generatedFromCCDTestClass.get(5).get("DisplayOrder")).isEqualTo("6");
     assertThat(generatedFromCCDTestClass.get(6).get("DisplayOrder")).isNull();


### PR DESCRIPTION
Add a displayOrder field to the CCD interface for complexFieldTypes
This allows control over the display order of the fields within the complexType when the complexType is added to a tab.



