### PR TITLE
Remove complex types from case event fields

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Field.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Field.java
@@ -45,7 +45,7 @@ public class Field<Type, StateType, Parent, Grandparent> {
       FieldBuilder result = new FieldBuilder();
       result.clazz = clazz;
       result.parent = parent;
-      result.context = DisplayContext.Complex;
+      result.context = DisplayContext.ReadOnly;
       result.id = id;
       return result;
     }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
@@ -345,16 +345,6 @@ public class FieldCollection {
       String fieldName = propertyUtils.getPropertyName(dataClass, getter);
       Optional<JsonUnwrapped> isUnwrapped = isUnwrappedField(dataClass, fieldName);
 
-      if (null == this.rootFieldname && isUnwrapped.isEmpty()) {
-        // Register only the root complex as a field
-        field(fieldName)
-            .context(DisplayContext.Complex)
-            .showSummary(summary)
-            .showCondition(showCondition)
-            .caseEventFieldLabel(label)
-            .caseEventFieldHint(hint);
-      }
-
       FieldCollectionBuilder<U, StateType, FieldCollectionBuilder<Type, StateType, Parent>> builder =
           complex(fieldName, c);
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
@@ -39,8 +39,7 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
           info.put("CaseTypeID", config.getCaseType());
           Field field = fb.build();
           info.put("CaseFieldID", field.getId());
-          String context =
-              field.getContext() == null ? "COMPLEX" : field.getContext().toString().toUpperCase();
+          String context = field.getContext().toString().toUpperCase();
           info.put("DisplayContext", context);
           info.put("PageFieldDisplayOrder", field.getPageFieldDisplayOrder());
 

--- a/ccd-config-generator/src/test/resources/ccd-definition/CaseEventToFields/addNotes.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/CaseEventToFields/addNotes.json
@@ -61,27 +61,13 @@
     "ShowSummaryChangeOption" : "Y"
   },
   {
-    "CaseEventFieldHint" : "Event hint",
-    "CaseEventFieldLabel" : "Event label",
-    "CaseEventID" : "addNotes",
-    "CaseFieldID" : "hearingPreferencesOrganisationPolicy",
-    "CaseTypeID" : "CARE_SUPERVISION_EPO",
-    "DisplayContext" : "COMPLEX",
-    "LiveFrom" : "01/01/2017",
-    "PageColumnNumber" : 1,
-    "PageDisplayOrder" : 1,
-    "PageFieldDisplayOrder" : 6,
-    "PageID" : 1,
-    "ShowSummaryChangeOption" : "Y"
-  },
-  {
     "PageID": 1,
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "caseName",
     "CaseEventID": "addNotes",
     "PageColumnNumber": 1,
-    "PageFieldDisplayOrder": 7,
+    "PageFieldDisplayOrder": 6,
     "DisplayContext": "OPTIONAL",
     "PageDisplayOrder": 1,
     "ShowSummaryChangeOption" : "Y"
@@ -95,7 +81,7 @@
     "LiveFrom" : "01/01/2017",
     "PageColumnNumber" : 1,
     "PageDisplayOrder" : 1,
-    "PageFieldDisplayOrder" : 8,
+    "PageFieldDisplayOrder" : 7,
     "PageID" : 1,
     "ShowSummaryChangeOption" : "Y"
   },
@@ -109,7 +95,7 @@
     "LiveFrom" : "01/01/2017",
     "PageColumnNumber" : 1,
     "PageDisplayOrder" : 1,
-    "PageFieldDisplayOrder" : 9,
+    "PageFieldDisplayOrder" : 8,
     "PageID" : 1,
     "ShowSummaryChangeOption" : "Y"
   },
@@ -122,7 +108,7 @@
     "LiveFrom" : "01/01/2017",
     "PageColumnNumber" : 1,
     "PageDisplayOrder" : 1,
-    "PageFieldDisplayOrder" : 10,
+    "PageFieldDisplayOrder" : 9,
     "PageID" : 1,
     "ShowSummaryChangeOption" : "Y"
   }

--- a/ccd-config-generator/src/test/resources/ccd-definition/CaseEventToFields/allocatedJudge.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/CaseEventToFields/allocatedJudge.json
@@ -3,36 +3,11 @@
     "PageID": "AllocatedJudge",
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "organisationPolicy",
-    "CaseEventID": "allocatedJudge",
-    "PageColumnNumber": 1,
-    "PageFieldDisplayOrder": 1,
-    "DisplayContext": "COMPLEX",
-    "ShowSummaryChangeOption": "Y",
-    "PageDisplayOrder": 1,
-    "CaseEventFieldHint" : "Event hint",
-    "CaseEventFieldLabel" : "Event label"
-  },
-  {
-    "PageID": "AllocatedJudge",
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "allocatedJudgeLabel",
     "CaseEventID": "allocatedJudge",
     "PageColumnNumber": 1,
-    "PageFieldDisplayOrder": 2,
+    "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
-    "PageDisplayOrder": 1
-  },
-  {
-    "PageID": "AllocatedJudge",
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "allocatedJudge",
-    "CaseEventID": "allocatedJudge",
-    "PageColumnNumber": 1,
-    "PageFieldDisplayOrder": 3,
-    "DisplayContext": "COMPLEX",
     "PageDisplayOrder": 1
   },
   {
@@ -57,7 +32,7 @@
     "DisplayContext" : "OPTIONAL",
     "LiveFrom" : "01/01/2017",
     "PageColumnNumber" : 1,
-    "PageFieldDisplayOrder": 4,
+    "PageFieldDisplayOrder": 2,
     "PageDisplayOrder" : 1,
     "PageID" : "AllocatedJudge",
     "ShowSummaryChangeOption" : "Y"


### PR DESCRIPTION
### Change description ###

This change removes complex types from the CaseEventsToFields tab. Previously it was in with a DisplayContext of COMPLEX which is not a valid value. This change does still generate permissions for the complex type if it's used in an event

