### PR TITLE
Remove unnecessary spring factories

### DIFF
--- a/ccd-config-generator/src/main/resources/META-INF/spring.factories
+++ b/ccd-config-generator/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  uk.gov.hmcts.ccd.sdk.MultiCaseTypeResolver


### PR DESCRIPTION
We don't need these factories and can instead rely on component scanning.



