### PR TITLE
Use Gradle's up-to-date checking

### DIFF
--- a/ccd-gradle-plugin/src/functionalTest/java/uk/gov/hmcts/ccd/sdk/FunctionalTest.java
+++ b/ccd-gradle-plugin/src/functionalTest/java/uk/gov/hmcts/ccd/sdk/FunctionalTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.sdk;
 
+import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
 import java.io.File;
@@ -7,8 +8,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.groovy.util.Maps;
+import org.gradle.api.Task;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,12 +33,13 @@ public class FunctionalTest {
     FileUtils.copyDirectory(new File("test-projects/java-library"),
         testProjectDir.getRoot());
     GradleRunner r = runner(testProjectDir.getRoot())
-        .withGradleVersion("4.10.3");
-    r.build();
+        .withGradleVersion("5.6.4");
+    assertEquals(TaskOutcome.SUCCESS,r.build().task(":generateCCDConfig").getOutcome());
     File caseField = new File(testProjectDir.getRoot(), "build/ccd-definition/test/CaseField.json");
     assertTrue(caseField.exists());
-    r.build(); // Run a second time to ensure a non-clean build succeeds.
-    assertTrue(caseField.exists());
+
+    // Run a second time to ensure a non-clean build without changes is up to date.
+    assertEquals(TaskOutcome.UP_TO_DATE,r.build().task(":generateCCDConfig").getOutcome());
   }
 
   public static GradleRunner runner(File project) {


### PR DESCRIPTION
Makes it possible for Gradle to skip running generateCCDConfig if it doesn't need to.



