### PR TITLE
Only give access to supplied states in .forStates() calls and only don't give any access for .forAllStates()

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -82,13 +83,23 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
       }
 
       @Override
+      public Event.EventBuilder<T, R, S> forStateTransition(S from, EnumSet to) {
+        return build(Set.of(from), to);
+      }
+
+      @Override
+      public Event.EventBuilder<T, R, S> forStateTransition(EnumSet from, EnumSet to) {
+        return build(from, to);
+      }
+
+      @Override
       public Event.EventBuilder<T, R, S> forAllStates() {
-        return build(config.allStates, config.allStates);
+        return build(config.allStates, Collections.emptySet());
       }
 
       @Override
       public Event.EventBuilder<T, R, S> forStates(S... states) {
-        return build(Set.of(states), config.allStates);
+        return build(Set.of(states), Set.of(states));
       }
 
       private Event.EventBuilder<T, R, S> build(Set<S> preStates, Set<S> postStates) {
@@ -144,7 +155,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
 
       @Override
       public Event.EventBuilder<T, R, S> forAllStates() {
-        return build(config.allStates, config.allStates);
+        return build(config.allStates, Collections.emptySet());
       }
 
       private Event.EventBuilder<T, R, S> build(Set<S> preStates, Set<S> postStates) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/EventTypeBuilder.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/EventTypeBuilder.java
@@ -12,6 +12,10 @@ public interface EventTypeBuilder<T, R extends HasRole, S> {
 
   Event.EventBuilder<T, R, S> forStateTransition(EnumSet from, S to);
 
+  Event.EventBuilder<T, R, S> forStateTransition(S from, EnumSet to);
+
+  Event.EventBuilder<T, R, S> forStateTransition(EnumSet from, EnumSet to);
+
   Event.EventBuilder<T, R, S> forAllStates();
 
   Event.EventBuilder<T, R, S> forStates(S... states);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
@@ -37,7 +37,8 @@ class AuthorisationCaseStateGenerator<T, S, R extends HasRole> implements Config
         // For state transitions if you have C then you get both states.
         // Otherwise you only need permission for the destination state.
         if (event.getPreState() != event.getPostState()) {
-          if (grants.get(role).contains(Permission.C) && !event.getPreState().isEmpty()) {
+          if (grants.get(role).contains(Permission.C) && !event.getPreState().isEmpty()
+              && !event.getPostState().isEmpty()) {
             addPermissions(config.getStateRolePermissions(), event.getPreState(), role,
                 grants.get(role));
             // They get R only on the destination state.

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -83,13 +83,10 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     }
 
     if (!event.getPreState().isEmpty()) {
-      data.put("PreConditionState(s)", toCCDStateString(event.getPreState(), allStates));
+      data.put("PreConditionState(s)", getPreStateString(event.getPreState(), allStates));
     }
-    // Event must target either on or all states
-    boolean isToAllStates = event.getPostState().equals(allStates);
-    // Events can either target a specific state or can be overridden to all.
-    assert event.getPostState().size() == 1 || isToAllStates;
-    data.put("PostConditionState", toCCDStateString(event.getPostState(), allStates));
+
+    data.put("PostConditionState", getPostStateString(event.getPostState()));
     data.put("SecurityClassification", "Public");
 
     if (event.getAboutToStartCallback() != null) {
@@ -122,11 +119,18 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     return result;
   }
 
-  private String toCCDStateString(Set<S> states, Set<S> allStates) {
+  private String getPreStateString(Set<S> states, Set<S> allStates) {
     return states.equals(allStates)
         ? "*"
         : states.stream().map(Objects::toString)
         .sorted()
         .collect(Collectors.joining(";"));
   }
+
+  private String getPostStateString(Set<S> states) {
+    return states.size() != 1
+      ? "*"
+      : states.stream().findFirst().map(Objects::toString).orElse("");
+  }
+
 }

--- a/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -75,5 +75,19 @@
     "CaseTypeID" : "CARE_SUPERVISION_EPO",
     "LiveFrom" : "01/01/2017",
     "UserRole" : "caseworker-publiclaw-systemupdate"
+  },
+  {
+    "CRUD" : "R",
+    "CaseEventID" : "checkReady",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-solicitor"
+  },
+  {
+    "CRUD" : "CRU",
+    "CaseEventID" : "checkReady",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-cafcass"
   }
 ]

--- a/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseState.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseState.json
@@ -17,13 +17,6 @@
     "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-courtadmin",
-    "CaseStateID": "Open"
-  },
-  {
-    "CRUD": "R",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "LiveFrom": "01/01/2017",
     "UserRole": "caseworker-publiclaw-cafcass",
     "CaseStateID": "Open"
   },
@@ -52,18 +45,18 @@
     "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-solicitor",
+    "UserRole": "caseworker-publiclaw-courtadmin",
     "CaseStateID": "Submitted"
   },
   {
     "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-courtadmin",
+    "UserRole": "caseworker-publiclaw-solicitor",
     "CaseStateID": "Submitted"
   },
   {
-    "CRUD": "R",
+    "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
     "UserRole": "caseworker-publiclaw-cafcass",
@@ -80,18 +73,18 @@
     "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-solicitor",
+    "UserRole": "caseworker-publiclaw-courtadmin",
     "CaseStateID": "Gatekeeping"
   },
   {
     "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-courtadmin",
+    "UserRole": "caseworker-publiclaw-solicitor",
     "CaseStateID": "Gatekeeping"
   },
   {
-    "CRUD": "R",
+    "CRUD": "CRU",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
     "UserRole": "caseworker-publiclaw-cafcass",
@@ -105,21 +98,7 @@
     "CaseStateID": "PREPARE_FOR_HEARING"
   },
   {
-    "CRUD": "R",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-solicitor",
-    "CaseStateID": "PREPARE_FOR_HEARING"
-  },
-  {
     "CRUD": "CRU",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-courtadmin",
-    "CaseStateID": "PREPARE_FOR_HEARING"
-  },
-  {
-    "CRUD": "R",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
     "UserRole": "caseworker-publiclaw-cafcass",
@@ -133,21 +112,7 @@
     "CaseStateID": "Deleted"
   },
   {
-    "CRUD": "R",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-solicitor",
-    "CaseStateID": "Deleted"
-  },
-  {
     "CRUD": "CRU",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "LiveFrom": "01/01/2017",
-    "UserRole": "caseworker-publiclaw-courtadmin",
-    "CaseStateID": "Deleted"
-  },
-  {
-    "CRUD": "R",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
     "UserRole": "caseworker-publiclaw-cafcass",

--- a/ccd-config-generator/src/test/resources/ccd-definition/CaseEvent/checkReady.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/CaseEvent/checkReady.json
@@ -1,0 +1,13 @@
+[
+  {
+    "CallBackURLAboutToSubmitEvent" : "${CCD_DEF_CASE_SERVICE_BASE_URL}/callbacks/about-to-submit?eventId=checkReady",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "Description" : "Add case notes",
+    "EndButtonLabel" : "Save and continue",
+    "ID" : "checkReady",
+    "LiveFrom" : "01/01/2017",
+    "Name" : "Add case notes",
+    "PostConditionState" : "*",
+    "PreConditionState(s)" : "*"
+  }
+]


### PR DESCRIPTION
### Change description ###

This PR changes the way AuthorisationCaseState is generated. Using .forAllStates() will no longer give access to all states. Using .forStates(A, B, C) will now only grant access to A, B ,C. Previously both granted access to all states.

In general inferring state permissions from the events is difficult as it's not possible for the library to know which post state permissions are required when they are set using a callback.

This PR also adds method overloads forStateTransition to allow mutliple post states. The post state will still be converted to `*` in the CCD configuration (as that's all CCD supports) the permissions will only be added for states mention in the pre and post enums. This allows the possibility of having events where the pre and post states don't overlap but you don't want to provide the user with access to every state.

