### PR TITLE
Make the payment history tab only for users with payment role

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseTypeTabGenerator.java
@@ -36,7 +36,9 @@ class CaseTypeTabGenerator<T, S, R extends HasRole> implements ConfigGenerator<T
       List<String> roles = tab.getForRolesAsString();
 
       // if no roles have been specified leave UserRole empty
-      if (roles.isEmpty()) {
+      if (tab.getTabID().equals("PaymentHistory")) {
+        roles = List.of("payments");
+      } else if (roles.isEmpty()) {
         roles.add("");
       }
 

--- a/ccd-config-generator/src/test/resources/ccd-definition/CaseTypeTab/12_PaymentHistorypayments.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/CaseTypeTab/12_PaymentHistorypayments.json
@@ -5,7 +5,7 @@
   "LiveFrom" : "01/01/2017",
   "TabDisplayOrder" : 12,
   "TabFieldDisplayOrder" : 1,
-  "TabID" : "PaymentHistory",
+  "TabID" : "PaymentHistorypayments",
   "TabLabel" : "Payment History",
-  "UserRole" : ""
+  "UserRole" : "payments"
 }]


### PR DESCRIPTION
### Change description ###

If you don't have the payments role the tab will be empty

