### PR TITLE
Spring boot devtools support

### DIFF
--- a/ccd-config-generator/src/main/resources/META-INF/spring-devtools.properties
+++ b/ccd-config-generator/src/main/resources/META-INF/spring-devtools.properties
@@ -1,0 +1,6 @@
+# Allow the config generator to work with spring boot devtools.
+# Classes from these jars can be preserved across live reloads
+# so they must be loaded on the devtools Restart classloader.
+# See https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.devtools.restart.customizing-the-classload
+restart.include.props=/de.cronn/reflection-util.+\\.jar
+restart.include.sdk=/ccd-config-generator.+\\.jar


### PR DESCRIPTION
Allows the config generator to be used with spring boot devtools for live reloading by ensuring the config generator is itself live reloaded.

See https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.devtools.restart.customizing-the-classload