### PR TITLE
Add option to specify inheritance model of access control

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
@@ -25,6 +25,8 @@ public @interface CCD {
 
   Class<? extends HasAccessControl>[] access() default {};
 
+  boolean inheritAccessFromParent() default true;
+
   boolean showSummaryContent() default false;
 
   boolean ignore() default false;

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseFieldGenerator.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.ArrayUtils;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
 import org.springframework.stereotype.Component;
@@ -179,9 +180,7 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
 
     for (java.lang.reflect.Field field : getCaseFields(parent)) {
       CCD ccdAnnotation = field.getAnnotation(CCD.class);
-      Class<? extends HasAccessControl>[] access = null != ccdAnnotation && ccdAnnotation.access().length > 0
-          ? ccdAnnotation.access()
-          : defaultAccessControl;
+      Class<? extends HasAccessControl>[] access = mergeAccess(defaultAccessControl, ccdAnnotation);
       JsonUnwrapped unwrapped = field.getAnnotation(JsonUnwrapped.class);
 
       if (null != unwrapped) {
@@ -207,5 +206,14 @@ class AuthorisationCaseFieldGenerator<T, S, R extends HasRole> implements Config
         }
       }
     }
+  }
+
+  private static Class<? extends HasAccessControl>[] mergeAccess(
+      Class<? extends HasAccessControl>[] defaultAccessControl, CCD ccdAnnotation) {
+    return null == ccdAnnotation || ccdAnnotation.access().length == 0
+        ? defaultAccessControl
+        : ccdAnnotation.inheritAccessFromParent()
+            ? ArrayUtils.addAll(defaultAccessControl, ccdAnnotation.access())
+            : ccdAnnotation.access();
   }
 }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/HearingPreferences.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/HearingPreferences.java
@@ -20,6 +20,8 @@ public class HearingPreferences {
     @CCD(label = "Do you want some Welsh?", access = {BulkScan.class})
     private String welsh;
     private String interpreter;
+
+    @CCD(access = {BulkScan.class}, inheritAccessFromParent = false)
     private Set<Refreshment> refreshments;
 
     @JsonUnwrapped(prefix = "locationPreferences")

--- a/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseField/caseworker-publiclaw-bulkscan.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseField/caseworker-publiclaw-bulkscan.json
@@ -26,5 +26,12 @@
     "CaseTypeID" : "CARE_SUPERVISION_EPO",
     "LiveFrom" : "01/01/2017",
     "UserRole" : "caseworker-publiclaw-bulkscan"
+  },
+  {
+    "CRUD" : "CRU",
+    "CaseFieldID" : "hearingPreferencesRefreshments",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-bulkscan"
   }
 ]

--- a/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseField/caseworker-publiclaw-bulkscansystemupdate.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseField/caseworker-publiclaw-bulkscansystemupdate.json
@@ -26,5 +26,12 @@
     "CaseTypeID" : "CARE_SUPERVISION_EPO",
     "LiveFrom" : "01/01/2017",
     "UserRole" : "caseworker-publiclaw-bulkscansystemupdate"
+  },
+  {
+    "CRUD" : "CRU",
+    "CaseFieldID" : "hearingPreferencesRefreshments",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-bulkscansystemupdate"
   }
 ]

--- a/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseField/caseworker-publiclaw-solicitor.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/AuthorisationCaseField/caseworker-publiclaw-solicitor.json
@@ -32,6 +32,13 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "UserRole": "caseworker-publiclaw-solicitor",
     "LiveFrom": "01/01/2017",
+    "CaseFieldID": "hearingPreferencesLocationPreferencesOnline"
+  },
+  {
+    "CRUD": "CRU",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "UserRole": "caseworker-publiclaw-solicitor",
+    "LiveFrom": "01/01/2017",
     "CaseFieldID": "hearingPreferencesOrganisationPolicy"
   },
   {
@@ -362,13 +369,6 @@
     "UserRole": "caseworker-publiclaw-solicitor",
     "LiveFrom": "01/01/2017",
     "CaseFieldID": "dateAndTimeSubmitted"
-  },
-  {
-    "CRUD": "CRU",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "UserRole": "caseworker-publiclaw-solicitor",
-    "LiveFrom": "01/01/2017",
-    "CaseFieldID": "hearingPreferencesRefreshments"
   },
   {
     "CRUD": "CRU",


### PR DESCRIPTION
### Change description ###

**This is a breaking change.**

Access control classes specified on unwrapped properties will now supplement the existing access control classes rather than replacing them. To revert to the old behaviour use the `inheritAccessFromParent` property on the `@CCD` annotation:

```
@CCD (
  access = {},
  inheritAccessFromParent = false
)
```
