### PR TITLE
Use deserializer to format milliseconds in case ending zeros are removed while persisting in CCD

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/deserializer/LocalDateTimeDeserializer.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/deserializer/LocalDateTimeDeserializer.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.ccd.sdk.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+public class LocalDateTimeDeserializer extends StdDeserializer<LocalDateTime> {
+
+  private static final long serialVersionUID = 1L;
+
+  protected LocalDateTimeDeserializer() {
+    super(LocalDateTime.class);
+  }
+
+  
+  @Override
+  public LocalDateTime deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    var dateString = jp.readValueAs(String.class);
+    DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 2, 3, true)
+            .toFormatter();
+    return LocalDateTime.parse(dateString, formatter);
+  }
+}

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ScannedDocument.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ScannedDocument.java
@@ -5,12 +5,13 @@ import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.deserializer.LocalDateTimeDeserializer;
 
 @Data
 @NoArgsConstructor
@@ -47,15 +48,15 @@ public class ScannedDocument {
   @CCD(
           label = "Scanned date"
   )
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
   private LocalDateTime scannedDate;
 
   @CCD(
           label = "Delivery date"
   )
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   private LocalDateTime deliveryDate;
 
   @CCD(


### PR DESCRIPTION
- We always received scanned date and delivery date with milliseconds consisting of 3 digits as bulk scan won’t allow less than 3 or more than 3 digits.
- But when milliseconds ends in something like 110 or 220 then looks like bulkscan service trims ending 0 when sending data to CCD.
- So for e.g if scanned date is `2022-04-27T11:25:46.420` then it is persisted as `2022-04-27T11:25:46.42`
- This then results in date format exception when we trigger callback in case api.




