### PR TITLE
nfdiv-2329: make milliseconds optional when parsing dateTime

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/deserializer/LocalDateTimeDeserializer.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/deserializer/LocalDateTimeDeserializer.java
@@ -17,13 +17,14 @@ public class LocalDateTimeDeserializer extends StdDeserializer<LocalDateTime> {
     super(LocalDateTime.class);
   }
 
-  
   @Override
   public LocalDateTime deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
     var dateString = jp.readValueAs(String.class);
     DateTimeFormatter formatter = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-            .appendFraction(ChronoField.MILLI_OF_SECOND, 2, 3, true)
+            .optionalStart()
+                  .appendFraction(ChronoField.MILLI_OF_SECOND, 1, 3, true)
+            .optionalEnd()
             .toFormatter();
     return LocalDateTime.parse(dateString, formatter);
   }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/deserializer/LocalDateTimeDeserializerTest.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/deserializer/LocalDateTimeDeserializerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.ccd.sdk.deserializer;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class LocalDateTimeDeserializerTest {
+
+  private ObjectMapper mapper;
+  private LocalDateTimeDeserializer deserializer;
+
+  @Before
+  public void setup() {
+    mapper = new ObjectMapper();
+    deserializer = new LocalDateTimeDeserializer();
+  }
+
+  @Test
+  public void shouldDeserializeDateTimeWithNoMilliSeconds() {
+    String dateTimeWithNoMilliSeconds = "{\"value\":\"2022-04-21T10:22:33\"}";
+
+    LocalDateTime deserializedValue = deserializeDateTime(dateTimeWithNoMilliSeconds);
+
+    assertDateValue(deserializedValue);
+  }
+
+  @Test
+  public void shouldDeserializeDateTimeWithTwoMilliSeconds() {
+    String dateTimeWithTwoMilliSeconds = "{\"value\":\"2022-04-21T10:22:33.44\"}";
+
+    LocalDateTime deserializedValue = deserializeDateTime(dateTimeWithTwoMilliSeconds);
+
+    assertDateValue(deserializedValue);
+  }
+
+  @Test
+  public void shouldDeserializeDateTimeWithThreeMilliSeconds() {
+    String dateTimeWithThreeMilliSeconds = "{\"value\":\"2022-04-21T10:22:33.555\"}";
+
+    LocalDateTime deserializedValue = deserializeDateTime(dateTimeWithThreeMilliSeconds);
+
+    assertDateValue(deserializedValue);
+  }
+
+  @Test
+  public void shouldDeserializeDateTimeWithOneMilliSeconds() {
+    String dateTimeWithOneMilliSecond = "{\"value\":\"2022-04-21T10:22:33.6\"}";
+
+    LocalDateTime deserializedValue = deserializeDateTime(dateTimeWithOneMilliSecond);
+
+    assertThat(deserializedValue, instanceOf(LocalDateTime.class));
+  }
+
+  @SneakyThrows({JsonParseException.class, IOException.class})
+  private LocalDateTime deserializeDateTime(String json) {
+    InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+    JsonParser parser = mapper.getFactory().createParser(stream);
+    DeserializationContext ctxt = mapper.getDeserializationContext();
+    parser.nextToken();
+    parser.nextToken();
+    parser.nextToken();
+    return deserializer.deserialize(parser, ctxt);
+  }
+
+  private void assertDateValue(LocalDateTime dateTime) {
+    assertThat(dateTime, instanceOf(LocalDateTime.class));
+
+    assertThat(dateTime.getYear(), equalTo(2022));
+    assertThat(dateTime.getMonthValue(), equalTo(4));
+    assertThat(dateTime.getDayOfMonth(), equalTo(21));
+    assertThat(dateTime.getHour(), equalTo(10));
+    assertThat(dateTime.getMinute(), equalTo(22));
+    assertThat(dateTime.getSecond(), equalTo(33));
+  }
+}


### PR DESCRIPTION
### Change description ###
- make milliseconds optional when parsing dateTime
- https://tools.hmcts.net/jira/browse/NFDIV-2329


