### PR TITLE
Remove name property

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
@@ -7,8 +7,6 @@ import uk.gov.hmcts.ccd.sdk.type.FieldType;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CCD {
 
-  String name() default "";
-
   String label() default "";
 
   String hint() default "";

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseRoleGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseRoleGenerator.java
@@ -27,8 +27,8 @@ public class CaseRoleGenerator<T, S, R extends HasRole> implements ConfigGenerat
     final Path path = Paths.get(rootOutputfolder.getPath(), "CaseRoles.json");
 
     final List<Map<String, Object>> caseRoles = Arrays.stream(config.getRoleClass().getEnumConstants())
-        .filter(x -> ((HasRole)x).getRole().matches("^\\[.+\\]$"))
-        .map(o -> enumToJsonMap(config.getCaseType(), config.getRoleClass(), o, ((HasRole) o).getRole()))
+        .filter(x -> x.getRole().matches("^\\[.+\\]$"))
+        .map(o -> enumToJsonMap(config.getCaseType(), config.getRoleClass(), o, o.getRole()))
         .collect(toList());
 
     mergeInto(path, caseRoles, new AddMissing(), "ID");
@@ -44,9 +44,9 @@ public class CaseRoleGenerator<T, S, R extends HasRole> implements ConfigGenerat
     field.put("ID", id);
 
     CCD ccd = enumType.getField(enumConstant.toString()).getAnnotation(CCD.class);
-    String name = ccd != null && !Strings.isNullOrEmpty(ccd.name()) ? ccd.name() :
+    String name = ccd != null && !Strings.isNullOrEmpty(ccd.label()) ? ccd.label() :
         enumConstant.toString();
-    String desc = ccd != null ? ccd.label() : "";
+    String desc = ccd != null ? ccd.hint() : "";
     field.put("Name", name);
     field.put("Description", desc);
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/FixedListGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/FixedListGenerator.java
@@ -36,14 +36,16 @@ class FixedListGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
           String enumName = ((Enum<?>)enumConstant).name();
           CCD annotation = c.getField(enumName).getAnnotation(CCD.class);
 
-          // use the enum label field, or the @CCD label, or the enumConstant
+          // use the enum label field, or the @CCD label, or the @CCD hint, or the enumConstant
           Object label = enumConstant instanceof HasLabel
               ? ((HasLabel) enumConstant).getLabel()
               : annotation == null
                   ? enumConstant
                   : !isNullOrEmpty(annotation.label())
                       ? annotation.label()
-                      : enumConstant;
+                      : !isNullOrEmpty(annotation.hint())
+                          ? annotation.hint()
+                          : enumConstant;
 
           Map<String, Object> value = Maps.newHashMap();
           fields.add(value);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/FixedListGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/FixedListGenerator.java
@@ -36,16 +36,14 @@ class FixedListGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
           String enumName = ((Enum<?>)enumConstant).name();
           CCD annotation = c.getField(enumName).getAnnotation(CCD.class);
 
-          // use the enum label field, or the @CCD name, or the @CCD label, or the enumConstant
+          // use the enum label field, or the @CCD label, or the enumConstant
           Object label = enumConstant instanceof HasLabel
               ? ((HasLabel) enumConstant).getLabel()
               : annotation == null
                   ? enumConstant
-                  : !isNullOrEmpty(annotation.name())
-                      ? annotation.name()
-                      : !isNullOrEmpty(annotation.label())
-                          ? annotation.label()
-                          : enumConstant;
+                  : !isNullOrEmpty(annotation.label())
+                      ? annotation.label()
+                      : enumConstant;
 
           Map<String, Object> value = Maps.newHashMap();
           fields.add(value);

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/StateGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/StateGenerator.java
@@ -43,11 +43,11 @@ class StateGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R
     field.put("ID", id);
 
     CCD ccd = enumType.getField(enumConstant.toString()).getAnnotation(CCD.class);
-    String name = ccd != null && !Strings.isNullOrEmpty(ccd.name()) ? ccd.name() :
+    String name = ccd != null && !Strings.isNullOrEmpty(ccd.label()) ? ccd.label() :
         enumConstant.toString();
     field.put("Name", name);
     field.put("Description", name);
-    String desc = ccd != null ? ccd.label() : "";
+    String desc = ccd != null ? ccd.hint() : "";
 
     if (!Strings.isNullOrEmpty(desc)) {
       field.put("TitleDisplay", desc);

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/ChildGender.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/ChildGender.java
@@ -8,13 +8,16 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public enum ChildGender {
 
-    @CCD(label = "boy")
+    @CCD(label = "boy", hint = "something")
     BOY("Boy"),
 
-    @CCD
+    @CCD(hint = "girl")
     GIRL("Girl"),
 
-    OTHER("They identify in another way");
+    @CCD
+    OTHER("They identify in another way"),
+
+    MULTI("Multiple genders");
 
     private final String label;
 

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/ChildGender.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/ChildGender.java
@@ -8,16 +8,13 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public enum ChildGender {
 
-    @CCD(name = "boy", label = "something")
+    @CCD(label = "boy")
     BOY("Boy"),
 
-    @CCD(label = "girl")
+    @CCD
     GIRL("Girl"),
 
-    @CCD
-    OTHER("They identify in another way"),
-
-    MULTI("Multiple genders");
+    OTHER("They identify in another way");
 
     private final String label;
 

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/State.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/State.java
@@ -5,20 +5,20 @@ import uk.gov.hmcts.reform.fpl.access.BulkScan;
 
 public enum State {
     @CCD(
-      name = "Initial case state – create title as a minimum; add documents, etc.",
+      label = "Initial case state – create title as a minimum; add documents, etc.",
       access = {BulkScan.class}
     )
     Open,
     @CCD(
-      name = "Submitted case state - LA can no longer edit",
-      label = "# **${[CASE_REFERENCE]}** ${applicant1LastName} **&** " +
+      label = "Submitted case state - LA can no longer edit",
+      hint = "# **${[CASE_REFERENCE]}** ${applicant1LastName} **&** " +
           "${applicant2LastName}\n" +
           "### **${[STATE]}**\n")
     Submitted,
-    @CCD(name = "Gatekeeping case state - when send to gatekeeper event is triggered")
+    @CCD(label = "Gatekeeping case state - when send to gatekeeper event is triggered")
     Gatekeeping,
-    @CCD(name = "State indicating that SDO is ready to send - triggered when SDO is issued")
+    @CCD(label = "State indicating that SDO is ready to send - triggered when SDO is issued")
     PREPARE_FOR_HEARING,
-    @CCD(name = "Deleted case state - all data is removed")
+    @CCD(label = "Deleted case state - all data is removed")
     Deleted
 }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/UserRole.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/enums/UserRole.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.fpl.enums;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.api.HasLabel;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 
 import java.util.List;
@@ -15,7 +16,7 @@ public enum UserRole implements HasRole {
     BULK_SCAN_SYSTEM_UPDATE("caseworker-publiclaw-bulkscansystemupdate"),
     CASE_ACCESS_ADMINISTRATOR("caseworker-caa"),
     CASE_ACCESS_APPROVER("caseworker-approver"),
-    @CCD(name = "Solicitor", label = "Solicitor role")
+    @CCD(label = "Solicitor", hint = "Solicitor role")
     CCD_SOLICITOR("[SOLICITOR]");
 
 

--- a/ccd-config-generator/src/test/resources/ccd-definition/FixedLists/ChildGender.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/FixedLists/ChildGender.json
@@ -7,7 +7,7 @@
   },
   {
     "ID" : "ChildGender",
-    "ListElement" : "girl",
+    "ListElement" : "GIRL",
     "ListElementCode" : "GIRL",
     "LiveFrom" : "01/01/2017"
   },
@@ -15,12 +15,6 @@
     "ID" : "ChildGender",
     "ListElement" : "OTHER",
     "ListElementCode" : "OTHER",
-    "LiveFrom" : "01/01/2017"
-  },
-  {
-    "ID" : "ChildGender",
-    "ListElement" : "MULTI",
-    "ListElementCode" : "MULTI",
     "LiveFrom" : "01/01/2017"
   }
 ]

--- a/ccd-config-generator/src/test/resources/ccd-definition/FixedLists/ChildGender.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/FixedLists/ChildGender.json
@@ -7,7 +7,7 @@
   },
   {
     "ID" : "ChildGender",
-    "ListElement" : "GIRL",
+    "ListElement" : "girl",
     "ListElementCode" : "GIRL",
     "LiveFrom" : "01/01/2017"
   },
@@ -15,6 +15,12 @@
     "ID" : "ChildGender",
     "ListElement" : "OTHER",
     "ListElementCode" : "OTHER",
+    "LiveFrom" : "01/01/2017"
+  },
+  {
+    "ID" : "ChildGender",
+    "ListElement" : "MULTI",
+    "ListElementCode" : "MULTI",
     "LiveFrom" : "01/01/2017"
   }
 ]


### PR DESCRIPTION
### Change description ###

Remove the name property from the `@CCD` annotation to provide a more consistent API when using the `@CCD` configuration in different contexts. 

This is a breaking change.

