### PR TITLE
NFDIV-2681: added temporary ignore unknown annotation to avoid draft doc failing mid events

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/Document.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/Document.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 @NoArgsConstructor
 @Builder
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = true) //added temporary to avoid draft doc failing mid events
 @ComplexType(name = "Document", generate = false)
 public class Document {
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/Document.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/Document.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.ccd.sdk.type;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +11,7 @@ import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 @NoArgsConstructor
 @Builder
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 @ComplexType(name = "Document", generate = false)
 public class Document {
 


### PR DESCRIPTION
### Change description ###

added temporary ignore unknown annotation to Documents to avoid draft doc failing mid events with error "Unrecognized field **document_hash**"

https://tools.hmcts.net/jira/browse/NFDIV-2681
