### PR TITLE
Add case role to access profiles tab

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import uk.gov.hmcts.ccd.sdk.api.CaseRoleToAccessProfile.CaseRoleToAccessProfileBuilder;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
@@ -32,6 +33,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   final List<SearchBuilder<T, R>> searchResultFields = Lists.newArrayList();
   final List<SearchBuilder<T, R>> searchInputFields = Lists.newArrayList();
   final List<SearchCasesBuilder<T>> searchCaseResultFields = Lists.newArrayList();
+  final List<CaseRoleToAccessProfileBuilder<R>> caseRoleToAccessProfiles = Lists.newArrayList();
   final Set<R> omitHistoryForRoles = new HashSet<>();
 
   public ConfigBuilderImpl(ResolvedCCDConfig<T, S, R> config) {
@@ -51,6 +53,7 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
     config.searchInputFields = buildBuilders(searchInputFields, SearchBuilder::build);
     config.searchCaseResultFields = buildBuilders(searchCaseResultFields, SearchCasesBuilder::build);
     config.rolesWithNoHistory = omitHistoryForRoles.stream().map(HasRole::getRole).collect(Collectors.toSet());
+    config.caseRoleToAccessProfiles = buildBuilders(caseRoleToAccessProfiles, CaseRoleToAccessProfileBuilder::build);
 
     return config;
   }
@@ -149,6 +152,13 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements ConfigBuilder
   public void addPreEventHook(
           Function<Map<String, Object>, Map<String, Object>> hook) {
     config.preEventHooks.add(hook);
+  }
+
+  @Override
+  public CaseRoleToAccessProfileBuilder<R> caseRoleToAccessProfile(R caseRole) {
+    var builder = CaseRoleToAccessProfileBuilder.builder(caseRole);
+    caseRoleToAccessProfiles.add(builder);
+    return builder;
   }
 
   private SearchBuilder<T, R> getWorkBasketBuilder(List<SearchBuilder<T, R>> workBasketInputFields) {

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CaseRoleToAccessProfile;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
@@ -51,4 +52,5 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
   List<Search<T, R>> searchResultFields;
   List<Search<T, R>> searchInputFields;
   List<SearchCases> searchCaseResultFields;
+  List<CaseRoleToAccessProfile> caseRoleToAccessProfiles;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CaseRoleToAccessProfile.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CaseRoleToAccessProfile.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.ccd.sdk.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class CaseRoleToAccessProfile<R extends HasRole> {
+  private R role;
+  private List<String> authorisation;
+  private boolean readonly;
+  private List<String> accessProfiles;
+  private boolean disabled;
+  private List<String> caseAccessCategories;
+
+  public static class CaseRoleToAccessProfileBuilder<R extends HasRole> {
+
+    public static <R extends HasRole> CaseRoleToAccessProfileBuilder<R> builder(R role) {
+      CaseRoleToAccessProfileBuilder<R> result = CaseRoleToAccessProfile.builder();
+      result.role = role;
+      result.authorisation = new ArrayList<>();
+      result.accessProfiles = new ArrayList<>();
+      result.caseAccessCategories = new ArrayList<>();
+      return result;
+    }
+
+    public CaseRoleToAccessProfileBuilder<R> authorisation(String... auth) {
+      authorisation.addAll(List.of(auth));
+
+      return this;
+    }
+
+    public CaseRoleToAccessProfileBuilder<R> accessProfiles(String... profiles) {
+      accessProfiles.addAll(List.of(profiles));
+
+      return this;
+    }
+
+    public CaseRoleToAccessProfileBuilder<R> caseAccessCategories(String... categories) {
+      caseAccessCategories.addAll(List.of(categories));
+
+      return this;
+    }
+
+    public CaseRoleToAccessProfileBuilder<R> readonly() {
+      readonly = true;
+
+      return this;
+    }
+
+    public CaseRoleToAccessProfileBuilder<R> disabled() {
+      disabled = true;
+
+      return this;
+    }
+  }
+}

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import uk.gov.hmcts.ccd.sdk.EventTypeBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseRoleToAccessProfile.CaseRoleToAccessProfileBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
 import uk.gov.hmcts.ccd.sdk.api.SearchCases.SearchCasesBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Tab.TabBuilder;
@@ -51,4 +52,6 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
   void setCallbackHost(String s);
 
   void addPreEventHook(Function<Map<String, Object>, Map<String, Object>> hook);
+
+  CaseRoleToAccessProfileBuilder<R> caseRoleToAccessProfile(R caseRole);
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/RoleToAccessProfilesGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/RoleToAccessProfilesGenerator.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.ccd.sdk.generator;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.join;
+import static uk.gov.hmcts.ccd.sdk.generator.JsonUtils.mergeInto;
+
+import com.google.common.collect.Maps;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseRoleToAccessProfile;
+import uk.gov.hmcts.ccd.sdk.api.HasRole;
+import uk.gov.hmcts.ccd.sdk.generator.JsonUtils.AddMissing;
+
+@Component
+public class RoleToAccessProfilesGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, S, R> {
+
+  @SneakyThrows
+  public void write(final File outputFolder, ResolvedCCDConfig<T, S, R> config) {
+
+    final Path path = Paths.get(outputFolder.getPath(), "RoleToAccessProfiles.json");
+
+    final List<Map<String, Object>> rows = config.getCaseRoleToAccessProfiles().stream()
+        .map(o -> toJson(config.getCaseType(), o))
+        .collect(toList());
+
+    mergeInto(path, rows, new AddMissing(), "RoleName");
+  }
+
+  @SneakyThrows
+  private static Map<String, Object> toJson(String caseType, CaseRoleToAccessProfile caseRoleToAccessProfile) {
+    Map<String, Object> field = Maps.newHashMap();
+    field.put("LiveFrom", "01/01/2017");
+    field.put("CaseTypeID", caseType);
+    field.put("RoleName", caseRoleToAccessProfile.getRole().getRole());
+    field.put("CaseAccessCategories", join(caseRoleToAccessProfile.getCaseAccessCategories(), ","));
+    field.put("Authorisation", join(caseRoleToAccessProfile.getAuthorisation(), ","));
+    field.put("ReadOnly", caseRoleToAccessProfile.isReadonly() ? "Y" : "N");
+    field.put("AccessProfiles", join(caseRoleToAccessProfile.getAccessProfiles(), ","));
+    field.put("Disabled", caseRoleToAccessProfile.isDisabled() ? "Y" : "N");
+    return field;
+  }
+
+}

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/FPLConfigGenerationTests.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/FPLConfigGenerationTests.java
@@ -119,6 +119,10 @@ public class FPLConfigGenerationTests {
         assertEquals("SearchInputFields.json");
     }
 
+    @Test
+    public void generatesRoleToAccessProfiles() {
+        assertEquals("RoleToAccessProfiles.json");
+    }
 
     @Test
     public void generatesAllComplexTypes() {

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -12,6 +12,7 @@ import static uk.gov.hmcts.reform.fpl.enums.State.Submitted;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.BULK_SCAN;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.BULK_SCAN_SYSTEM_UPDATE;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.CAFCASS;
+import static uk.gov.hmcts.reform.fpl.enums.UserRole.CASE_ACCESS_ADMINISTRATOR;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.CASE_ACCESS_APPROVER;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.CCD_SOLICITOR;
 import static uk.gov.hmcts.reform.fpl.enums.UserRole.HMCTS_ADMIN;
@@ -103,6 +104,18 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
         .optionalWithLabel(CaseData::getGatekeeperEmail, "Gate keeper email")
         .mandatoryWithoutDefaultValue(CaseData::getAllocatedJudge, "hearingPreferencesWelsh=\"yes\"", "Judge is bilingual", true)
         .mandatoryWithLabel(CaseData::getCaseLocalAuthority, "Please enter a case local authority");
+
+    builder.caseRoleToAccessProfile(CASE_ACCESS_APPROVER)
+      .accessProfiles("access-profile", "access-profile2")
+      .authorisation("authorisation", "authorisation2")
+      .caseAccessCategories("case-access-category", "case-access-category2");
+
+    builder.caseRoleToAccessProfile(CASE_ACCESS_ADMINISTRATOR)
+      .accessProfiles("access-profile")
+      .authorisation("authorisation")
+      .caseAccessCategories("case-access-category")
+      .readonly()
+      .disabled();
   }
 
   private AboutToStartOrSubmitResponse<CaseData, State> checkReadyAboutToSubmit(CaseDetails<CaseData, State> details,

--- a/ccd-config-generator/src/test/resources/ccd-definition/RoleToAccessProfiles.json
+++ b/ccd-config-generator/src/test/resources/ccd-definition/RoleToAccessProfiles.json
@@ -1,0 +1,22 @@
+[
+  {
+    "AccessProfiles": "access-profile,access-profile2",
+    "Authorisation": "authorisation,authorisation2",
+    "CaseAccessCategories": "case-access-category,case-access-category2",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "Disabled": "N",
+    "LiveFrom": "01/01/2017",
+    "ReadOnly": "N",
+    "RoleName": "caseworker-approver"
+  },
+  {
+    "AccessProfiles": "access-profile",
+    "Authorisation": "authorisation",
+    "CaseAccessCategories": "case-access-category",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "Disabled": "Y",
+    "LiveFrom": "01/01/2017",
+    "ReadOnly": "Y",
+    "RoleName": "caseworker-caa"
+  }
+]


### PR DESCRIPTION
### Change description ###

Add the CaseRoleToAccessProfiles tab: https://tools.hmcts.net/confluence/display/RCCD/CCD+Definition+Glossary+for+Setting+up+a+Service+in+CCD#CCDDefinitionGlossaryforSettingupaServiceinCCD-ccdDefTabRoleToAccessProfiles

